### PR TITLE
즐겨찾기 추가 & 삭제 기능 구현

### DIFF
--- a/src/main/java/com/sparta/kidscafe/common/dto/StatusDto.java
+++ b/src/main/java/com/sparta/kidscafe/common/dto/StatusDto.java
@@ -1,11 +1,16 @@
 package com.sparta.kidscafe.common.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 @Getter
 @SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
 public class StatusDto {
+
   private int status;
   private String message;
 }

--- a/src/main/java/com/sparta/kidscafe/domain/bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/sparta/kidscafe/domain/bookmark/controller/BookmarkController.java
@@ -1,12 +1,35 @@
 package com.sparta.kidscafe.domain.bookmark.controller;
 
+import com.sparta.kidscafe.common.dto.StatusDto;
 import com.sparta.kidscafe.domain.bookmark.service.BookmarkService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api")
 public class BookmarkController {
 
   private final BookmarkService bookmarkService;
+
+  @PostMapping("/cafes/{cafeId}/bookmarks")
+  public ResponseEntity<StatusDto> toggleBookmark(
+      @Valid @PathVariable(value = "cafeId") Long cafeId) {
+
+    boolean isBookmarked = bookmarkService.toggleBookmark(1L, cafeId);
+
+    if (isBookmarked) {
+      return ResponseEntity.status(HttpStatus.CREATED)
+          .body(StatusDto.builder().status(HttpStatus.CREATED.value()).message("즐겨찾기 추가").build());
+    } else {
+      return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+  }
+
 }

--- a/src/main/java/com/sparta/kidscafe/domain/bookmark/dto/request/BookmarkCreateRequestDto.java
+++ b/src/main/java/com/sparta/kidscafe/domain/bookmark/dto/request/BookmarkCreateRequestDto.java
@@ -1,4 +1,14 @@
 package com.sparta.kidscafe.domain.bookmark.dto.request;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class BookmarkCreateRequestDto {
+
+  private Long userId;
+  private Long cafeId;
 }

--- a/src/main/java/com/sparta/kidscafe/domain/bookmark/dto/response/BookmarkResponseDto.java
+++ b/src/main/java/com/sparta/kidscafe/domain/bookmark/dto/response/BookmarkResponseDto.java
@@ -1,4 +1,24 @@
 package com.sparta.kidscafe.domain.bookmark.dto.response;
 
+import com.sparta.kidscafe.domain.bookmark.entity.Bookmark;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
 public class BookmarkResponseDto {
+
+  private Long id;
+  private Long userId;
+  private Long cafeId;
+
+  public static BookmarkResponseDto from(Bookmark bookmark) {
+    return new BookmarkResponseDto(
+        bookmark.getId(),
+        bookmark.getUser().getId(),
+        bookmark.getCafe().getId()
+    );
+  }
 }

--- a/src/main/java/com/sparta/kidscafe/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/com/sparta/kidscafe/domain/bookmark/entity/Bookmark.java
@@ -3,6 +3,8 @@ package com.sparta.kidscafe.domain.bookmark.entity;
 import com.sparta.kidscafe.common.entity.Timestamped;
 import com.sparta.kidscafe.domain.cafe.entity.Cafe;
 import com.sparta.kidscafe.domain.user.entity.User;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -15,6 +17,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 @Getter
 @Builder
@@ -23,15 +27,18 @@ import lombok.NoArgsConstructor;
 @Entity
 @Table(name = "bookmark")
 public class Bookmark extends Timestamped {
+
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "user_id")
+  @JoinColumn(name = "user_id", nullable = false)
+  @OnDelete(action = OnDeleteAction.CASCADE)
   private User user;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "cafe_id")
+  @JoinColumn(name = "cafe_id", nullable = false)
+  @OnDelete(action = OnDeleteAction.CASCADE)
   private Cafe cafe;
 }

--- a/src/main/java/com/sparta/kidscafe/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/sparta/kidscafe/domain/bookmark/repository/BookmarkRepository.java
@@ -1,7 +1,15 @@
 package com.sparta.kidscafe.domain.bookmark.repository;
 
 import com.sparta.kidscafe.domain.bookmark.entity.Bookmark;
+import com.sparta.kidscafe.domain.cafe.entity.Cafe;
+import com.sparta.kidscafe.domain.user.entity.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+
+  Optional<Bookmark> findByUserAndCafe(User user, Cafe cafe);
+
 }

--- a/src/main/java/com/sparta/kidscafe/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/sparta/kidscafe/domain/bookmark/service/BookmarkService.java
@@ -1,11 +1,46 @@
 package com.sparta.kidscafe.domain.bookmark.service;
 
+import com.sparta.kidscafe.domain.bookmark.entity.Bookmark;
 import com.sparta.kidscafe.domain.bookmark.repository.BookmarkRepository;
+import com.sparta.kidscafe.domain.cafe.entity.Cafe;
+import com.sparta.kidscafe.domain.cafe.repository.CafeRepository;
+import com.sparta.kidscafe.domain.user.entity.User;
+import com.sparta.kidscafe.domain.user.repository.UserRepository;
+import com.sparta.kidscafe.exception.BusinessException;
+import com.sparta.kidscafe.exception.ErrorCode;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class BookmarkService {
+
   private final BookmarkRepository bookmarkRepository;
+  private final CafeRepository cafeRepository;
+  private final UserRepository userRepository;
+
+
+  // 즐겨찾기 추가 & 삭제 로직: @return true: 즐겨찾기에 추가, false: 즐겨찾기에서 삭제
+  public boolean toggleBookmark(Long userId, Long cafeId) {
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    Cafe cafe = cafeRepository.findById(cafeId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.CAFE_NOT_FOUND));
+
+    Optional<Bookmark> bookmarkOptional = bookmarkRepository.findByUserAndCafe(user, cafe);
+
+    if (bookmarkOptional.isPresent()) {
+      // 즐겨찾기에 있는 경우 삭제
+      bookmarkRepository.delete(bookmarkOptional.get());
+      return false;
+    } else {
+      Bookmark bookmark = Bookmark.builder()
+          .user(user)
+          .cafe(cafe)
+          .build();
+      bookmarkRepository.save(bookmark);
+      return true;
+    }
+  }
 }

--- a/src/test/java/com/sparta/kidscafe/domain/bookmark/service/BookmarkServiceTest.java
+++ b/src/test/java/com/sparta/kidscafe/domain/bookmark/service/BookmarkServiceTest.java
@@ -1,4 +1,90 @@
 package com.sparta.kidscafe.domain.bookmark.service;
 
+import com.sparta.kidscafe.domain.bookmark.entity.Bookmark;
+import com.sparta.kidscafe.domain.bookmark.repository.BookmarkRepository;
+import com.sparta.kidscafe.domain.cafe.entity.Cafe;
+import com.sparta.kidscafe.domain.cafe.repository.CafeRepository;
+import com.sparta.kidscafe.domain.user.entity.User;
+import com.sparta.kidscafe.domain.user.repository.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
 public class BookmarkServiceTest {
+
+  @InjectMocks
+  private BookmarkService bookmarkService;
+
+  @Mock
+  private BookmarkRepository bookmarkRepository;
+
+  @Mock
+  private CafeRepository cafeRepository;
+
+  @Mock
+  private UserRepository userRepository;
+
+  @Test
+  @DisplayName("즐겨찾기 추가: 성공")
+  void addToggleBookmark_success() {
+    // Given
+    Long userId = 1L;
+    Long cafeId = 1L;
+
+    User user = new User();
+    Cafe cafe = new Cafe();
+
+    Mockito.when(userRepository.findById(userId))
+        .thenReturn(Optional.of(user));
+    Mockito.when(cafeRepository.findById(cafeId))
+        .thenReturn(Optional.of(cafe));
+    Mockito.when(bookmarkRepository.findByUserAndCafe(user, cafe))
+        .thenReturn(Optional.empty());
+
+    // When
+    boolean result = bookmarkService.toggleBookmark(userId, cafeId);
+
+    // Then
+    Assertions.assertTrue(result);
+    Mockito.verify(bookmarkRepository, Mockito.times(1))
+        .save(Mockito.any(Bookmark.class));
+    Mockito.verify(bookmarkRepository, Mockito.never())
+        .delete(Mockito.any(Bookmark.class));
+  }
+
+  @Test
+  @DisplayName("즐겨찾기 추가: 실패 = 삭제")
+  void addToggleBookmark_fail() {
+    // Given
+    Long userId = 1L;
+    Long cafeId = 1L;
+
+    User user = new User();
+    Cafe cafe = new Cafe();
+    Bookmark bookmark = new Bookmark();
+
+    Mockito.when(userRepository.findById(userId))
+        .thenReturn(Optional.of(user));
+    Mockito.when(cafeRepository.findById(cafeId))
+        .thenReturn(Optional.of(cafe));
+    Mockito.when(bookmarkRepository.findByUserAndCafe(user, cafe))
+        .thenReturn(Optional.of(bookmark));
+
+    // When
+    boolean result = bookmarkService.toggleBookmark(userId, cafeId);
+
+    // Then
+    Assertions.assertFalse(result);
+    Mockito.verify(bookmarkRepository, Mockito.times(1))
+        .delete(bookmark);
+    Mockito.verify(bookmarkRepository, Mockito.never())
+        .save(Mockito.any(Bookmark.class));
+  }
 }


### PR DESCRIPTION
### 시나리오
- `POST` `/api/cafes/{cafeId}/bookmarks`

1. 사용자가 관심있는 키즈 카페를 즐겨찾기에 추가
2. 즐겨찾기 목록에 존재하지 않는 경우 추가
3. 목록에 존재하지 않는 경우 삭제

### 단위 테스트 
- BookmarkServiceTest에서 진행

1. 즐겨찾기 추가: 성공 (목록에 없는 경우)
2. 즐겨찾기 추가: 실패 = 삭제 (목록에 존재하는 경우)