### PR TITLE
즐겨찾기 조회(사용자용) 기능 구현

### DIFF
--- a/src/main/java/com/sparta/kidscafe/common/dto/PageResponseDto.java
+++ b/src/main/java/com/sparta/kidscafe/common/dto/PageResponseDto.java
@@ -13,6 +13,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @SuperBuilder(builderMethodName = "createResponseBuilder")
 public class PageResponseDto<T> extends StatusDto {
+
   private List<T> data;
   private int page;
   private int size;

--- a/src/main/java/com/sparta/kidscafe/domain/bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/sparta/kidscafe/domain/bookmark/controller/BookmarkController.java
@@ -1,14 +1,20 @@
 package com.sparta.kidscafe.domain.bookmark.controller;
 
+import com.sparta.kidscafe.common.annotation.Auth;
+import com.sparta.kidscafe.common.dto.AuthUser;
+import com.sparta.kidscafe.common.dto.PageResponseDto;
 import com.sparta.kidscafe.common.dto.StatusDto;
+import com.sparta.kidscafe.domain.bookmark.dto.response.BookmarkUserRetreiveResponseDto;
 import com.sparta.kidscafe.domain.bookmark.service.BookmarkService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -18,11 +24,13 @@ public class BookmarkController {
 
   private final BookmarkService bookmarkService;
 
+  // 즐겨찾기 추가 & 삭제(토글식)
   @PostMapping("/cafes/{cafeId}/bookmarks")
   public ResponseEntity<StatusDto> toggleBookmark(
+      @Auth AuthUser authUser,
       @Valid @PathVariable(value = "cafeId") Long cafeId) {
 
-    boolean isBookmarked = bookmarkService.toggleBookmark(1L, cafeId);
+    boolean isBookmarked = bookmarkService.toggleBookmark(authUser.getId(), cafeId);
 
     if (isBookmarked) {
       return ResponseEntity.status(HttpStatus.CREATED)
@@ -32,4 +40,14 @@ public class BookmarkController {
     }
   }
 
+  // 즐겨찾기 조회(User용)
+  @GetMapping("/users/bookmarks")
+  public ResponseEntity<PageResponseDto<BookmarkUserRetreiveResponseDto>> getBookmarks(
+      @Auth AuthUser authUser,
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "10") int size) {
+    PageResponseDto<BookmarkUserRetreiveResponseDto> response = bookmarkService.getBookmark(
+        authUser.getId(), page, size);
+    return ResponseEntity.ok(response);
+  }
 }

--- a/src/main/java/com/sparta/kidscafe/domain/bookmark/dto/response/BookmarkUserRetreiveResponseDto.java
+++ b/src/main/java/com/sparta/kidscafe/domain/bookmark/dto/response/BookmarkUserRetreiveResponseDto.java
@@ -1,0 +1,19 @@
+package com.sparta.kidscafe.domain.bookmark.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class BookmarkUserRetreiveResponseDto {
+  private Long cafeId;
+  private String cafeName;
+
+  public BookmarkUserRetreiveResponseDto(Long cafeId, String cafeName) {
+    this.cafeId = cafeId;
+    this.cafeName = cafeName;
+  }
+
+
+
+}

--- a/src/main/java/com/sparta/kidscafe/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/com/sparta/kidscafe/domain/bookmark/entity/Bookmark.java
@@ -41,4 +41,9 @@ public class Bookmark extends Timestamped {
   @JoinColumn(name = "cafe_id", nullable = false)
   @OnDelete(action = OnDeleteAction.CASCADE)
   private Cafe cafe;
+
+  public Bookmark(User user, Cafe cafe) {
+    this.user = user;
+    this.cafe = cafe;
+  }
 }

--- a/src/main/java/com/sparta/kidscafe/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/sparta/kidscafe/domain/bookmark/repository/BookmarkRepository.java
@@ -4,6 +4,8 @@ import com.sparta.kidscafe.domain.bookmark.entity.Bookmark;
 import com.sparta.kidscafe.domain.cafe.entity.Cafe;
 import com.sparta.kidscafe.domain.user.entity.User;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -12,4 +14,5 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
   Optional<Bookmark> findByUserAndCafe(User user, Cafe cafe);
 
+  Page<Bookmark> findAllByUserId(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/sparta/kidscafe/domain/cafe/entity/Cafe.java
+++ b/src/main/java/com/sparta/kidscafe/domain/cafe/entity/Cafe.java
@@ -93,4 +93,9 @@ public class Cafe extends Timestamped {
   @Builder.Default
   @OneToMany(mappedBy = "cafe", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
   private List<PricePolicy> pricePolicies = new ArrayList<>();
+
+  public Cafe(Long id, String name) {
+    this.id = id;
+    this.name = name;
+  }
 }

--- a/src/main/java/com/sparta/kidscafe/domain/user/entity/User.java
+++ b/src/main/java/com/sparta/kidscafe/domain/user/entity/User.java
@@ -66,4 +66,10 @@ public class User extends Timestamped {
   @Builder.Default
   @OneToMany(mappedBy = "user", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
   private List<Reservation> reservations = new ArrayList<>();
+
+  public User (Long id, String email, RoleType role) {
+    this.id = id;
+    this.email = email;
+    this.role = role;
+  }
 }

--- a/src/main/java/com/sparta/kidscafe/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/kidscafe/exception/ErrorCode.java
@@ -20,6 +20,9 @@ public enum ErrorCode {
     // Reservation 관련 에러
     RESERVATION_NOT_FOUND("RESERVATION_NOT_FOUND", "예약을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 
+    // Bookmark 관련 에러
+    NO_BOOKMARKS_FOUND("NO_BOOKMARKS_FOUND", "즐겨찾기 목록이 비어있습니다.", HttpStatus.NOT_FOUND),
+
     // === guguggagga ===
     CAFE_IMAGE_UPLOAD_FAILED("", "카페 이미지 업로드 실패", HttpStatus.INTERNAL_SERVER_ERROR),
     // ==================

--- a/src/test/java/com/sparta/kidscafe/api/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/sparta/kidscafe/api/auth/service/AuthServiceTest.java
@@ -47,7 +47,8 @@ class AuthServiceTest {
 			"test",
 			"test si test gu test dong",
 			"testNickname",
-			"default");
+			"default",
+				"USER");
 		when(userRepository.existsByEmail(any())).thenReturn(true);
 
 		// when // then
@@ -66,7 +67,8 @@ class AuthServiceTest {
 			"test1",
 			"test address",
 			"testNickname1",
-			"default"
+			"default",
+				"USER"
 		);
 		when(userRepository.existsByEmail(any())).thenReturn(false);
 

--- a/src/test/java/com/sparta/kidscafe/domain/bookmark/service/BookmarkServiceTest.java
+++ b/src/test/java/com/sparta/kidscafe/domain/bookmark/service/BookmarkServiceTest.java
@@ -1,11 +1,24 @@
 package com.sparta.kidscafe.domain.bookmark.service;
 
+import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+import com.sparta.kidscafe.common.dto.PageResponseDto;
+import com.sparta.kidscafe.common.enums.RoleType;
+import com.sparta.kidscafe.domain.bookmark.dto.response.BookmarkUserRetreiveResponseDto;
 import com.sparta.kidscafe.domain.bookmark.entity.Bookmark;
 import com.sparta.kidscafe.domain.bookmark.repository.BookmarkRepository;
 import com.sparta.kidscafe.domain.cafe.entity.Cafe;
 import com.sparta.kidscafe.domain.cafe.repository.CafeRepository;
 import com.sparta.kidscafe.domain.user.entity.User;
 import com.sparta.kidscafe.domain.user.repository.UserRepository;
+import com.sparta.kidscafe.exception.BusinessException;
+import com.sparta.kidscafe.exception.ErrorCode;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -15,6 +28,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+
 
 @ExtendWith(MockitoExtension.class)
 public class BookmarkServiceTest {
@@ -86,5 +106,97 @@ public class BookmarkServiceTest {
         .delete(bookmark);
     Mockito.verify(bookmarkRepository, Mockito.never())
         .save(Mockito.any(Bookmark.class));
+  }
+
+  @Test
+  @DisplayName("사용자 전용 즐겨찾기 조회: 성공")
+  void getBookmark_success() {
+    // Given
+    Long userId = 1L;
+    int page = 0;
+    int size = 10;
+
+    User user = User.builder()
+        .id(userId)
+        .role(RoleType.USER)
+        .build();
+
+    List<Bookmark> bookmarks = List.of(
+        Bookmark.builder()
+            .cafe(Cafe.builder().id(101L).name("Cafe A").build())
+            .build(),
+        Bookmark.builder()
+            .cafe(Cafe.builder().id(102L).name("Cafe B").build())
+            .build()
+    );
+    Page<Bookmark> mockPage = new PageImpl<>(bookmarks, PageRequest.of(page, size),
+        bookmarks.size());
+
+    Mockito.when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    Mockito.when(bookmarkRepository.findAllByUserId(userId, PageRequest.of(page, size, Sort.by(
+        Direction.DESC, "createdAt")))).thenReturn(mockPage);
+
+    // When
+    PageResponseDto<BookmarkUserRetreiveResponseDto> response = bookmarkService.getBookmark(userId,
+        page, size);
+
+    // Then
+    assertNotNull(response);
+    assertEquals(2, response.getData().size());
+    assertEquals("즐겨찾기 조회(사용자용) 성공", response.getMessage());
+    assertEquals(1, response.getPage());
+    assertEquals(10, response.getSize());
+    assertEquals(1, response.getTotalPage());
+
+    BookmarkUserRetreiveResponseDto responseDto = response.getData().get(0);
+    assertEquals(101L, responseDto.getCafeId());
+    assertEquals("Cafe A", responseDto.getCafeName());
+  }
+
+  @Test
+  @DisplayName("인증되지 않은 사용자가 즐겨찾기 조회를 시도한 경우")
+  void getBookmark_UserNotFound() {
+    // Given
+    Long userId = 1L;
+    given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+    // When & Then
+    BusinessException ex = assertThrows(BusinessException.class, () ->
+        bookmarkService.getBookmark(userId, 0, 10)
+    );
+    assertEquals(ErrorCode.USER_NOT_FOUND, ex.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("사용자(User) 권한이 없는 경우")
+  void getBookmark_Unauthorized() {
+    // Given
+    Long userId = 1L;
+    User user = new User(userId, "test@example.com", RoleType.ADMIN); // 비권한 사용자
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+    // When & Then
+    BusinessException ex = assertThrows(BusinessException.class, () ->
+        bookmarkService.getBookmark(userId, 0, 10)
+    );
+    assertEquals(ErrorCode.UNAUTHORIZED, ex.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("즐겨찾기 목록이 비어있는 경우")
+  void getBookmark_NoBookmarks() {
+    // Given
+    Long userId = 1L;
+    User user = new User(userId, "test@example.com", RoleType.USER);
+    Page<Bookmark> emptyPage = Page.empty();
+    given(userRepository.findById(userId)).willReturn(Optional.of(user));
+    given(bookmarkRepository.findAllByUserId(eq(userId), any(Pageable.class))).willReturn(
+        emptyPage);
+
+    // When & Then
+    BusinessException ex = assertThrows(BusinessException.class, () ->
+        bookmarkService.getBookmark(userId, 0, 10)
+    );
+    assertEquals(ErrorCode.NO_BOOKMARKS_FOUND, ex.getErrorCode());
   }
 }


### PR DESCRIPTION
### 시나리오
- `GET` `/api/users/bookmarks`

1. 사용자가 추가한 즐겨찾기 목록 조회
2. 사용자(USER)가 아닌 사장(OWNER)인 경우 예외처리

### 단위 테스트 
- BookmarkServiceTest에서 진행

1. 사용자 전용 즐겨찾기 조회 성공 케이스
2. 인증되지 않은 사용자가 즐겨찾기 조회를 시도한 경우
3. 사용자(User) 권한이 없는 경우
4. 즐겨찾기 목록이 비어있는 경우

### 관련 이슈
#55 