### PR TITLE
feat: 가격 정책 CRUD 및 조회 API 구현 #37

### DIFF
--- a/src/main/java/com/sparta/kidscafe/domain/pricepolicy/controller/PricePolicyController.java
+++ b/src/main/java/com/sparta/kidscafe/domain/pricepolicy/controller/PricePolicyController.java
@@ -1,11 +1,14 @@
 package com.sparta.kidscafe.domain.pricepolicy.controller;
 
 import com.sparta.kidscafe.domain.pricepolicy.dto.request.PricePolicyCreateRequestDto;
+import com.sparta.kidscafe.domain.pricepolicy.dto.response.PricePolicyResponseDto;
 import com.sparta.kidscafe.domain.pricepolicy.service.PricePolicyService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/cafes/{cafeId}/prices")
@@ -21,5 +24,11 @@ public class PricePolicyController {
   ) {
     pricePolicyService.addPricePolicy(cafeId, requestDto);
     return ResponseEntity.status(201).body("가격 정책이 추가되었습니다.");
+  }
+
+  @GetMapping
+  public ResponseEntity<List<PricePolicyResponseDto>> getPricePolicies(@PathVariable Long cafeId) {
+    List<PricePolicyResponseDto> policies = pricePolicyService.getPricePolicies(cafeId);
+    return ResponseEntity.ok(policies);
   }
 }

--- a/src/main/java/com/sparta/kidscafe/domain/pricepolicy/dto/request/PricePolicyCreateRequestDto.java
+++ b/src/main/java/com/sparta/kidscafe/domain/pricepolicy/dto/request/PricePolicyCreateRequestDto.java
@@ -14,7 +14,7 @@ import lombok.*;
 public class PricePolicyCreateRequestDto {
 
     @NotNull(message = "TargetType은 필수 입력값입니다.")
-    private TargetType targetType; // 정책 대상 종류 (FEE, ROOM, PEOPLE 등)
+    private TargetType targetType; // 정책 대상 종류 (FEE, ROOM)
 
     @NotNull(message = "Target ID는 필수 입력값입니다.")
     @Positive(message = "Target ID는 양수만 허용됩니다.")

--- a/src/main/java/com/sparta/kidscafe/domain/pricepolicy/dto/response/PricePolicyResponseDto.java
+++ b/src/main/java/com/sparta/kidscafe/domain/pricepolicy/dto/response/PricePolicyResponseDto.java
@@ -1,5 +1,32 @@
 package com.sparta.kidscafe.domain.pricepolicy.dto.response;
 
-public class PricePolicyResponseDto {
+import com.sparta.kidscafe.common.enums.TargetType;
+import com.sparta.kidscafe.domain.pricepolicy.entity.PricePolicy;
+import lombok.Builder;
+import lombok.Getter;
 
+@Getter
+@Builder
+public class PricePolicyResponseDto {
+    private Long id;           // 정책 ID
+    private String title;      // 정책 제목
+    private Long cafeId;       // 카페 ID
+    private TargetType targetType; // 정책 대상 종류
+    private Long targetId;     // 대상 ID
+    private String targetName; // 대상 이름
+    private String dayType;    // 적용 요일
+    private Double rate;       // 요금 비율
+
+    public static PricePolicyResponseDto fromEntity(PricePolicy policy, String targetName) {
+        return PricePolicyResponseDto.builder()
+                .id(policy.getId())
+                .title(policy.getTitle())
+                .cafeId(policy.getCafe().getId())
+                .targetType(policy.getTargetType())
+                .targetId(policy.getTargetId())
+                .targetName(targetName)
+                .dayType(policy.getDayType())
+                .rate(policy.getRate())
+                .build();
+    }
 }

--- a/src/main/java/com/sparta/kidscafe/domain/pricepolicy/entity/PricePolicy.java
+++ b/src/main/java/com/sparta/kidscafe/domain/pricepolicy/entity/PricePolicy.java
@@ -50,4 +50,15 @@ public class PricePolicy extends Timestamped {
 
   @Column(nullable = false)
   private double rate;
+
+  public String getTargetName() {
+    if (targetType == TargetType.FEE) {
+      return switch (targetId.intValue()) {
+        case 1 -> "[어린이] 0~2세";
+        case 2 -> "[어린이] 3~5세";
+        default -> "기타 대상";
+      };
+    }
+    return targetType.getName();
+  }
 }

--- a/src/main/java/com/sparta/kidscafe/domain/pricepolicy/repository/PricePolicyRepository.java
+++ b/src/main/java/com/sparta/kidscafe/domain/pricepolicy/repository/PricePolicyRepository.java
@@ -3,6 +3,8 @@ package com.sparta.kidscafe.domain.pricepolicy.repository;
 import com.sparta.kidscafe.domain.pricepolicy.entity.PricePolicy;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PricePolicyRepository extends JpaRepository<PricePolicy, Long> {
+import java.util.List;
 
+public interface PricePolicyRepository extends JpaRepository<PricePolicy, Long> {
+    List<PricePolicy> findAllByCafeId(Long cafeId);
 }

--- a/src/main/java/com/sparta/kidscafe/domain/pricepolicy/service/PricePolicyService.java
+++ b/src/main/java/com/sparta/kidscafe/domain/pricepolicy/service/PricePolicyService.java
@@ -4,12 +4,16 @@ package com.sparta.kidscafe.domain.pricepolicy.service;
 import com.sparta.kidscafe.domain.cafe.entity.Cafe;
 import com.sparta.kidscafe.domain.cafe.repository.CafeRepository;
 import com.sparta.kidscafe.domain.pricepolicy.dto.request.PricePolicyCreateRequestDto;
+import com.sparta.kidscafe.domain.pricepolicy.dto.response.PricePolicyResponseDto;
 import com.sparta.kidscafe.domain.pricepolicy.entity.PricePolicy;
 import com.sparta.kidscafe.domain.pricepolicy.repository.PricePolicyRepository;
 import com.sparta.kidscafe.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -36,5 +40,14 @@ public class PricePolicyService {
 
     // 3. 저장
     pricePolicyRepository.save(pricePolicy);
+  }
+
+  @Transactional(readOnly = true)
+  public List<PricePolicyResponseDto> getPricePolicies(Long cafeId) {
+    List<PricePolicy> pricePolicies = pricePolicyRepository.findAllByCafeId(cafeId);
+
+    return pricePolicies.stream()
+            .map(policy -> PricePolicyResponseDto.fromEntity(policy, policy.getTargetName()))
+            .collect(Collectors.toList());
   }
 }


### PR DESCRIPTION
- PricePolicy 엔티티에 getTargetName 메서드 추가
- PricePolicyController: 정책 추가(POST), 조회(GET) API 구현
- PricePolicyService: 정책 추가 및 조회 로직 구현
- PricePolicyRepository: Cafe ID 기반 정책 조회 메서드 추가
- PricePolicyCreateRequestDto 및 ResponseDto 수정: 유효성 검증 및 변환 메서드 추가