### PR TITLE
feat: 카페 조회 기능 구현 (사용자가 검색한)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,7 @@ dependencies {
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
 
     // querydsl 추가
+    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
@@ -61,6 +62,9 @@ dependencies {
     // Cache
     implementation 'org.springframework.boot:spring-boot-starter-cache'
     implementation 'com.github.ben-manes.caffeine:caffeine'
+
+    // 직렬화 & 역직렬화
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 
     // Testing
     testImplementation 'org.springframework.boot:spring-boot-starter-test' // Spring Boot Test
@@ -73,7 +77,7 @@ test {
     def isBuild = project.hasProperty('excludeTests')
     useJUnitPlatform() { // JUnit 플랫폼 사용
         if(isBuild) {
-            excludeTags("dummy-test")
+            excludeTags('dummy-test')
         }
     }
 }

--- a/src/main/java/com/sparta/kidscafe/api/filter/HeaderTokenValidFilter.java
+++ b/src/main/java/com/sparta/kidscafe/api/filter/HeaderTokenValidFilter.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -34,6 +35,13 @@ public class HeaderTokenValidFilter extends OncePerRequestFilter {
 	}
 
 	public boolean isApplicable(HttpServletRequest request) {
-		return request.getRequestURI().startsWith("/api/auth");
+		// 회원 가입, 로그인 관련 API 는 인증 필요 없이 요청 진행
+		String url = request.getRequestURI();
+		if (!StringUtils.hasText(url))
+			return true;
+		return url.startsWith("/api/auth") ||
+				url.contains("api/cafes") ||
+				url.startsWith("/css") ||
+				url.startsWith("/js");
 	}
 }

--- a/src/main/java/com/sparta/kidscafe/common/config/JPAConfig.java
+++ b/src/main/java/com/sparta/kidscafe/common/config/JPAConfig.java
@@ -1,0 +1,18 @@
+package com.sparta.kidscafe.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JPAConfig {
+  @PersistenceContext
+  private EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
+}

--- a/src/main/java/com/sparta/kidscafe/common/config/PasswordConfig.java
+++ b/src/main/java/com/sparta/kidscafe/common/config/PasswordConfig.java
@@ -1,0 +1,25 @@
+package com.sparta.kidscafe.common.config;
+
+import com.sparta.kidscafe.common.util.PasswordEncoder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Spring Security   에서 사용되는 비밀번호 암호화 설정을 담당하는 클래스입니다.
+ *
+ * @since 2024-10-17
+ */
+@Configuration
+public class PasswordConfig {
+
+  /**
+   * Spring Security에서 사용되는 비밀번호 암호화 객체를 생성하여 Bean으로 등록합니다. BCryptPasswordEncoder 클래스를 사용하여 비밀번호를
+   * 암호화합니다.
+   *
+   * @return Bean으로 등록된 PasswordEncoder 객체
+   */
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new PasswordEncoder(); // 비밀번호를 암호화해주는 hash 함수
+  }
+}

--- a/src/main/java/com/sparta/kidscafe/common/config/PasswordConfig.java
+++ b/src/main/java/com/sparta/kidscafe/common/config/PasswordConfig.java
@@ -1,18 +1,25 @@
-// package com.sparta.kidscafe.common.config;
-//
-// import org.springframework.stereotype.Component;
-//
-// import at.favre.lib.crypto.bcrypt.BCrypt;
-//
-// @Component
-// public class PasswordConfig {
-//
-//   public String encode(String password){
-//     return BCrypt.withDefaults().hashToString(BCrypt.MIN_COST, password.toCharArray());
-//   }
-//
-//   public boolean matches(String password, String encodedPassword){
-//     BCrypt.Result result = BCrypt.verifyer().verify(password.toCharArray(), encodedPassword);
-//     return result.verified;
-//   }
-// }
+package com.sparta.kidscafe.common.config;
+
+import com.sparta.kidscafe.common.util.PasswordEncoder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Spring Security   에서 사용되는 비밀번호 암호화 설정을 담당하는 클래스입니다.
+ *
+ * @since 2024-10-17
+ */
+@Configuration
+public class PasswordConfig {
+
+  /**
+   * Spring Security에서 사용되는 비밀번호 암호화 객체를 생성하여 Bean으로 등록합니다. BCryptPasswordEncoder 클래스를 사용하여 비밀번호를
+   * 암호화합니다.
+   *
+   * @return Bean으로 등록된 PasswordEncoder 객체
+   */
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new PasswordEncoder(); // 비밀번호를 암호화해주는 hash 함수
+  }
+}

--- a/src/main/java/com/sparta/kidscafe/common/dto/PageResponseDto.java
+++ b/src/main/java/com/sparta/kidscafe/common/dto/PageResponseDto.java
@@ -21,12 +21,14 @@ public class PageResponseDto<T> extends StatusDto {
 
   public static <T> PageResponseDto<T> success(Page<T> data, HttpStatus status, String message) {
     Pageable pageable = data.getPageable();
+    int page = pageable.isPaged() ? pageable.getPageNumber() + 1 : 0;
+    int size = pageable.isPaged() ? pageable.getPageSize() : 0;
     return PageResponseDto.<T>createResponseBuilder()
-        .data(data.stream().toList())
+        .data(data.hasContent() ? data.getContent() : null)
         .status(status.value())
         .message(message)
-        .page(pageable.getPageNumber() + 1)
-        .size(pageable.getPageSize())
+        .page(page)
+        .size(size)
         .totalPage(data.getTotalPages())
         .build();
   }

--- a/src/main/java/com/sparta/kidscafe/common/dto/PageResponseDto.java
+++ b/src/main/java/com/sparta/kidscafe/common/dto/PageResponseDto.java
@@ -13,6 +13,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 @SuperBuilder(builderMethodName = "createResponseBuilder")
 public class PageResponseDto<T> extends StatusDto {
+
   private List<T> data;
   private int page;
   private int size;
@@ -20,12 +21,14 @@ public class PageResponseDto<T> extends StatusDto {
 
   public static <T> PageResponseDto<T> success(Page<T> data, HttpStatus status, String message) {
     Pageable pageable = data.getPageable();
+    int page = pageable.isPaged() ? pageable.getPageNumber() + 1 : 0;
+    int size = pageable.isPaged() ? pageable.getPageSize() : 0;
     return PageResponseDto.<T>createResponseBuilder()
-        .data(data.stream().toList())
+        .data(data.hasContent() ? data.getContent() : null)
         .status(status.value())
         .message(message)
-        .page(pageable.getPageNumber() + 1)
-        .size(pageable.getPageSize())
+        .page(page)
+        .size(size)
         .totalPage(data.getTotalPages())
         .build();
   }

--- a/src/main/java/com/sparta/kidscafe/domain/cafe/controller/CafeController.java
+++ b/src/main/java/com/sparta/kidscafe/domain/cafe/controller/CafeController.java
@@ -1,7 +1,10 @@
 package com.sparta.kidscafe.domain.cafe.controller;
 
+import com.sparta.kidscafe.common.dto.PageResponseDto;
 import com.sparta.kidscafe.common.dto.StatusDto;
 import com.sparta.kidscafe.domain.cafe.dto.request.CafeCreateRequestDto;
+import com.sparta.kidscafe.domain.cafe.dto.request.CafeSearchRequestDto;
+import com.sparta.kidscafe.domain.cafe.dto.response.CafeResponseDto;
 import com.sparta.kidscafe.domain.cafe.service.CafeService;
 import com.sparta.kidscafe.domain.user.entity.User;
 import jakarta.validation.Valid;
@@ -9,7 +12,9 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -33,5 +38,13 @@ public class CafeController {
     return ResponseEntity
         .status(HttpStatus.CREATED)
         .body(cafeService.createCafe(user, requestDto, cafeImages));
+  }
+
+  @GetMapping("/cafes")
+  public ResponseEntity<PageResponseDto<CafeResponseDto>> searchCafe(
+      @Valid @RequestBody CafeSearchRequestDto requestDto
+  ) {
+    return ResponseEntity.status(HttpStatus.OK)
+        .body(cafeService.searchCafe(requestDto.getSearchCondition()));
   }
 }

--- a/src/main/java/com/sparta/kidscafe/domain/cafe/dto/SearchCondition.java
+++ b/src/main/java/com/sparta/kidscafe/domain/cafe/dto/SearchCondition.java
@@ -1,0 +1,32 @@
+package com.sparta.kidscafe.domain.cafe.dto;
+
+import com.sparta.kidscafe.domain.cafe.enums.SearchSortBy;
+import java.time.LocalTime;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Pageable;
+
+@Builder
+@Getter
+public class SearchCondition {
+
+  private String name;
+  private String region;
+  private int size;
+  private String ageGroup;
+  private int minPrice;
+  private int maxPrice;
+  private double minStar;
+  private double maxStar;
+  private boolean parking;
+  private boolean opening;
+  private boolean existRestaurant;
+  private boolean existRoom;
+  private boolean adultPrice;
+  private boolean multiFamily;
+  private LocalTime openedAt;
+  private LocalTime closedAt;
+  private Pageable pageable;
+  private SearchSortBy sortBy;
+  private boolean asc;
+}

--- a/src/main/java/com/sparta/kidscafe/domain/cafe/dto/request/CafeSearchRequestDto.java
+++ b/src/main/java/com/sparta/kidscafe/domain/cafe/dto/request/CafeSearchRequestDto.java
@@ -1,0 +1,87 @@
+package com.sparta.kidscafe.domain.cafe.dto.request;
+
+import com.sparta.kidscafe.domain.cafe.dto.SearchCondition;
+import com.sparta.kidscafe.domain.cafe.enums.SearchSortBy;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
+import java.time.LocalTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CafeSearchRequestDto {
+
+  private String name;
+  private String region;
+
+  @Positive(message = "카페 크기는 0이상입니다.")
+  private int size;
+
+  @NotNull(message = "연령대가 비어있습니다.")
+  private String ageGroup;
+
+  @Positive(message = "최소 금액은 0원 이상입니다.")
+  private int minPrice;
+
+  @Positive(message = "최대 금액은 0원 이상입니다.")
+  private int maxPrice;
+
+  @DecimalMin(value = "0.0", message = "최소 별점은 0.0 이상이어야 합니다.")
+  private double minStar;
+
+  @DecimalMax(value = "5.0", message = "최대 별점은 5.0 이하여야 합니다.")
+  private double maxStar;
+  private boolean parking;
+  private boolean opening;
+  private boolean existRestaurant;
+  private boolean existRoom;
+  private boolean adultPrice;
+  private boolean multiFamily;
+
+  @Pattern(
+      regexp = "^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$",
+      message = "오픈 시간은 'hh:mm' 형식이어야 하며, 00:00부터 23:59까지만 가능합니다."
+  )
+  private String openedAt;
+
+  @Pattern(
+      regexp = "^(0[0-9]|1[0-9]|2[0-3]):[0-5][0-9]$",
+      message = "마감 시간은 'hh:mm' 형식이어야 하며, 00:00부터 23:59까지만 가능합니다."
+  )
+  private String closedAt;
+
+  private int page;
+  private int pageSize;
+  private SearchSortBy sortBy;
+  private boolean asc;
+
+  public SearchCondition getSearchCondition() {
+    return SearchCondition.builder()
+        .name(name)
+        .region(region)
+        .size(size)
+        .ageGroup(ageGroup)
+        .minPrice(minPrice)
+        .maxPrice(maxPrice)
+        .minStar(minStar)
+        .maxStar(maxStar)
+        .parking(parking)
+        .opening(opening)
+        .existRestaurant(existRestaurant)
+        .existRoom(existRoom)
+        .multiFamily(multiFamily)
+        .openedAt(LocalTime.parse(openedAt))
+        .closedAt(LocalTime.parse(closedAt))
+        .sortBy(sortBy)
+        .asc(asc)
+        .pageable(PageRequest.of(page - 1, pageSize))
+        .build();
+  }
+}

--- a/src/main/java/com/sparta/kidscafe/domain/cafe/dto/response/CafeResponseDto.java
+++ b/src/main/java/com/sparta/kidscafe/domain/cafe/dto/response/CafeResponseDto.java
@@ -1,4 +1,51 @@
 package com.sparta.kidscafe.domain.cafe.dto.response;
 
+import com.querydsl.core.annotations.QueryProjection;
+import java.time.LocalTime;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
 public class CafeResponseDto {
+
+  private Long id;
+  private String name;
+  private String address;
+  private int size;
+  private double star;
+  private Long reviewCount;
+  private boolean existRoom;
+  private boolean parking;
+  private boolean restaurantExists;
+  private LocalTime openedAt;
+  private LocalTime closedAt;
+
+  @QueryProjection
+  public CafeResponseDto(
+      Long id,
+      String name,
+      String address,
+      int size,
+      double star,
+      Long reviewCount,
+      boolean existRoom, // boolean
+      boolean parking,
+      boolean restaurantExists,
+      LocalTime openedAt,
+      LocalTime closedAt) {
+    this.id = id;
+    this.name = name;
+    this.address = address;
+    this.size = size;
+    this.star = star;
+    this.reviewCount = reviewCount;
+    this.existRoom = existRoom;
+    this.parking = parking;
+    this.restaurantExists = restaurantExists;
+    this.openedAt = openedAt;
+    this.closedAt = closedAt;
+  }
 }

--- a/src/main/java/com/sparta/kidscafe/domain/cafe/enums/SearchSortBy.java
+++ b/src/main/java/com/sparta/kidscafe/domain/cafe/enums/SearchSortBy.java
@@ -1,0 +1,32 @@
+package com.sparta.kidscafe.domain.cafe.enums;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum SearchSortBy {
+  CAFE_NAME,
+  REVIEW_COUNT,
+  REVIEW_AVG,
+  ROOM_EXIST,
+  OPENED_AT,
+  CLOSED_AT;
+
+  @JsonCreator
+  public static SearchSortBy getAgeGroup(String name) {
+    for (SearchSortBy ageGroup : SearchSortBy.values()) {
+      if (ageGroup.toString().equals(name)) {
+        return ageGroup;
+      }
+    }
+    return CAFE_NAME;
+  }
+
+  @JsonValue
+  public String getName() {
+    return toString();
+  }
+}

--- a/src/main/java/com/sparta/kidscafe/domain/cafe/repository/CafeDslRepository.java
+++ b/src/main/java/com/sparta/kidscafe/domain/cafe/repository/CafeDslRepository.java
@@ -1,0 +1,9 @@
+package com.sparta.kidscafe.domain.cafe.repository;
+
+import com.sparta.kidscafe.domain.cafe.dto.SearchCondition;
+import com.sparta.kidscafe.domain.cafe.dto.response.CafeResponseDto;
+import org.springframework.data.domain.Page;
+
+public interface CafeDslRepository {
+  Page<CafeResponseDto> searchCafe(SearchCondition condition);
+}

--- a/src/main/java/com/sparta/kidscafe/domain/cafe/repository/CafeDslRepositoryImpl.java
+++ b/src/main/java/com/sparta/kidscafe/domain/cafe/repository/CafeDslRepositoryImpl.java
@@ -1,0 +1,116 @@
+package com.sparta.kidscafe.domain.cafe.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sparta.kidscafe.domain.cafe.dto.SearchCondition;
+import com.sparta.kidscafe.domain.cafe.dto.response.CafeResponseDto;
+import com.sparta.kidscafe.domain.cafe.dto.response.QCafeResponseDto;
+import com.sparta.kidscafe.domain.cafe.entity.QCafe;
+import com.sparta.kidscafe.domain.cafe.repository.condition.CafeCondition;
+import com.sparta.kidscafe.domain.cafe.repository.condition.FeeCondition;
+import com.sparta.kidscafe.domain.cafe.repository.condition.ReviewCondition;
+import com.sparta.kidscafe.domain.cafe.repository.condition.RoomCondition;
+import com.sparta.kidscafe.domain.fee.entity.QFee;
+import com.sparta.kidscafe.domain.review.entity.QReview;
+import com.sparta.kidscafe.domain.room.entity.QRoom;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+
+@RequiredArgsConstructor
+public class CafeDslRepositoryImpl implements CafeDslRepository {
+
+  private final JPAQueryFactory queryFactory;
+  private final RoomCondition roomCondition;
+  private final ReviewCondition reviewCondition;
+  private final CafeCondition cafeCondition;
+  private final FeeCondition feeCondition;
+  private final QCafe cafe = QCafe.cafe;
+  private final QRoom room = QRoom.room;
+  private final QReview review = QReview.review;
+  private final QFee fee = new QFee("fee");
+
+  @Override
+  public Page<CafeResponseDto> searchCafe(SearchCondition condition) {
+    long cntTotal = searchCafeTotalCount(condition);
+    if (cntTotal == 0) {
+      return Page.empty();
+    }
+
+    List<CafeResponseDto> cafes = queryFactory.select(new QCafeResponseDto(
+            cafe.id,
+            cafe.name,
+            cafe.address,
+            cafe.size,
+            review.star.avg(),
+            review.id.countDistinct(),
+            roomCondition.existRoom(),
+            cafe.parking,
+            cafe.restaurant,
+            cafe.openedAt,
+            cafe.closedAt))
+        .from(cafe)
+        .leftJoin(review).on(review.cafe.eq(cafe))
+        .leftJoin(room).on(room.cafe.eq(cafe))
+        .leftJoin(fee).on(fee.cafe.eq(cafe))
+        .where(makeWhere(condition))
+        .groupBy(cafe.id)
+        .having(makeHaving(condition))
+        .orderBy(makeOrderBy(condition))
+        .limit(condition.getPageable().getPageSize())
+        .offset(condition.getPageable().getOffset())
+        .fetch();
+    return new PageImpl<>(cafes, condition.getPageable(), cntTotal);
+  }
+
+  private long searchCafeTotalCount(SearchCondition condition) {
+    Long cntTotal = queryFactory
+        .select(cafe.id.countDistinct())
+        .from(cafe)
+        .leftJoin(review).on(review.cafe.eq(cafe))
+        .leftJoin(room).on(room.cafe.eq(cafe))
+        .leftJoin(fee).on(fee.cafe.eq(cafe))
+        .where(makeWhere(condition))
+        .groupBy(cafe.id)
+        .having(makeHaving(condition))
+        .orderBy(makeOrderBy(condition)).fetchFirst();
+    return cntTotal == null ? 0 : cntTotal;
+  }
+
+  private BooleanBuilder makeWhere(SearchCondition condition) {
+    BooleanBuilder builder = new BooleanBuilder();
+    builder.and(cafeCondition.likeName(condition.getName()));
+    builder.and(cafeCondition.eqRegion(condition.getRegion()));
+    builder.and(cafeCondition.loeSize(condition.getSize()));
+    builder.and(feeCondition.ageGroup(condition));
+    builder.and(cafeCondition.parking(condition.isParking()));
+    builder.and(cafeCondition.isOpening(condition.isOpening()));
+    builder.and(cafeCondition.restaurantExists(condition.isExistRestaurant()));
+    builder.and(feeCondition.adultPrice(condition.isAdultPrice()));
+    builder.and(cafeCondition.multiFamily(condition.isMultiFamily()));
+    builder.and(cafeCondition.goeOpenedAt(condition.getOpenedAt()));
+    builder.and(cafeCondition.loeClosedAt(condition.getClosedAt()));
+    return builder;
+  }
+
+  private BooleanBuilder makeHaving(SearchCondition condition) {
+    BooleanBuilder builder = new BooleanBuilder();
+    builder.and(reviewCondition.betweenAvgStar(condition));
+    builder.and(roomCondition.existRoom(condition.isExistRoom()));
+    return builder;
+  }
+
+  private OrderSpecifier<?> makeOrderBy(SearchCondition condition) {
+    boolean isAsc = condition.isAsc();
+    return switch (condition.getSortBy()) {
+      case REVIEW_COUNT -> isAsc ? review.id.count().asc() : review.id.count().desc();
+      case REVIEW_AVG -> isAsc ? review.star.avg().asc() : review.star.avg().desc();
+      case ROOM_EXIST -> isAsc ? roomCondition.existRoom().asc() :
+          roomCondition.existRoom().desc();
+      default -> new OrderSpecifier<>(Order.ASC, cafe.name);
+    };
+  }
+}

--- a/src/main/java/com/sparta/kidscafe/domain/cafe/repository/CafeRepository.java
+++ b/src/main/java/com/sparta/kidscafe/domain/cafe/repository/CafeRepository.java
@@ -3,5 +3,5 @@ package com.sparta.kidscafe.domain.cafe.repository;
 import com.sparta.kidscafe.domain.cafe.entity.Cafe;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CafeRepository extends JpaRepository<Cafe, Long> {
+public interface CafeRepository extends JpaRepository<Cafe, Long>, CafeDslRepository {
 }

--- a/src/main/java/com/sparta/kidscafe/domain/cafe/repository/condition/CafeCondition.java
+++ b/src/main/java/com/sparta/kidscafe/domain/cafe/repository/condition/CafeCondition.java
@@ -1,0 +1,105 @@
+package com.sparta.kidscafe.domain.cafe.repository.condition;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.sparta.kidscafe.domain.cafe.entity.QCafe;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.TextStyle;
+import java.util.Locale;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+public class CafeCondition {
+
+  private final QCafe cafe = QCafe.cafe;
+
+  public BooleanExpression likeName(String name) {
+    if (!StringUtils.hasText(name)) {
+      return null;
+    }
+
+    return cafe.name.contains(name);
+  }
+
+  public BooleanExpression eqRegion(String region) {
+    if (region == null || region.isEmpty()) {
+      return null;
+    }
+    return cafe.region.eq(region);
+  }
+
+  public BooleanExpression loeSize(int size) {
+    if (size < 0) {
+      return null;
+    }
+    return cafe.size.loe(size);
+  }
+
+  public BooleanExpression parking(boolean parking) {
+    if (parking) {
+      return cafe.parking.isTrue();
+    } else {
+      return cafe.parking.isFalse();
+    }
+  }
+
+  public Predicate isOpening(boolean opening) {
+    if (!opening) {
+      return null;
+    }
+
+    LocalTime currentTime = LocalTime.now();
+    String today = LocalDate
+        .now()
+        .getDayOfWeek()
+        .getDisplayName(TextStyle.SHORT, Locale.KOREAN);
+
+    BooleanBuilder innerBuilder = new BooleanBuilder();
+    innerBuilder.and(cafe.dayOff.contains(today));
+    innerBuilder.and(cafe.openedAt.goe(currentTime));
+    innerBuilder.and(cafe.openedAt.loe(currentTime));
+    return innerBuilder.getValue();
+  }
+
+  public Predicate dayOff(String dayOff) {
+    BooleanBuilder innerBuilder = new BooleanBuilder();
+    String[] days = dayOff.split(", ");
+    for (String day : days) {
+      innerBuilder.and(cafe.dayOff.eq(day));
+    }
+    return innerBuilder.getValue();
+  }
+
+  public BooleanExpression restaurantExists(boolean restaurant) {
+    if (restaurant) {
+      return cafe.restaurant.isTrue();
+    } else {
+      return cafe.restaurant.isFalse();
+    }
+  }
+
+  public BooleanExpression multiFamily(boolean multiFamily) {
+    if (multiFamily) {
+      return cafe.multiFamily.isTrue();
+    } else {
+      return cafe.multiFamily.isFalse();
+    }
+  }
+
+  public BooleanExpression goeOpenedAt(LocalTime openedAt) {
+    if (openedAt == null) {
+      return null;
+    }
+    return cafe.openedAt.goe(openedAt);
+  }
+
+  public BooleanExpression loeClosedAt(LocalTime closedAt) {
+    if (closedAt == null) {
+      return null;
+    }
+    return cafe.closedAt.loe(closedAt);
+  }
+}

--- a/src/main/java/com/sparta/kidscafe/domain/cafe/repository/condition/FeeCondition.java
+++ b/src/main/java/com/sparta/kidscafe/domain/cafe/repository/condition/FeeCondition.java
@@ -1,0 +1,48 @@
+package com.sparta.kidscafe.domain.cafe.repository.condition;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.sparta.kidscafe.common.enums.AgeGroup;
+import com.sparta.kidscafe.domain.cafe.dto.SearchCondition;
+import com.sparta.kidscafe.domain.fee.entity.QFee;
+import java.util.Arrays;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+public class FeeCondition {
+
+  private final QFee fee = new QFee("fee");
+
+  public Predicate ageGroup(SearchCondition condition) {
+    if (StringUtils.hasText(condition.getAgeGroup())) {
+      return null;
+    }
+
+    BooleanBuilder builder = new BooleanBuilder();
+    if (!StringUtils.hasText(condition.getAgeGroup())) {
+      builder.and(eqAgeGroup(condition.getAgeGroup()));
+      builder.and(betweenPrice(condition.getMinPrice(), condition.getMaxPrice()));
+    }
+    return builder.getValue();
+  }
+
+  public BooleanExpression eqAgeGroup(String ageGroup) {
+    if (ageGroup == null || ageGroup.isEmpty()) {
+      return null;
+    }
+    return fee.ageGroup.eq(AgeGroup.getAgeGroup(ageGroup));
+  }
+
+  public BooleanExpression betweenPrice(int minPrice, int maxPrice) {
+    return fee.fee.between(minPrice, maxPrice);
+  }
+
+  public BooleanExpression adultPrice(boolean isAdultPrice) {
+    if (!isAdultPrice) {
+      return null;
+    }
+    return fee.ageGroup.notIn(Arrays.asList(AgeGroup.BABY, AgeGroup.TEENAGER));
+  }
+}

--- a/src/main/java/com/sparta/kidscafe/domain/cafe/repository/condition/ReviewCondition.java
+++ b/src/main/java/com/sparta/kidscafe/domain/cafe/repository/condition/ReviewCondition.java
@@ -1,0 +1,19 @@
+package com.sparta.kidscafe.domain.cafe.repository.condition;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.sparta.kidscafe.domain.cafe.dto.SearchCondition;
+import com.sparta.kidscafe.domain.review.entity.QReview;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ReviewCondition {
+
+  private final QReview review = QReview.review;
+
+  public BooleanExpression betweenAvgStar(SearchCondition condition) {
+    return review.star.avg().between(
+        condition.getMinStar(),
+        condition.getMaxStar()
+    );
+  }
+}

--- a/src/main/java/com/sparta/kidscafe/domain/cafe/repository/condition/RoomCondition.java
+++ b/src/main/java/com/sparta/kidscafe/domain/cafe/repository/condition/RoomCondition.java
@@ -1,0 +1,27 @@
+package com.sparta.kidscafe.domain.cafe.repository.condition;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.sparta.kidscafe.domain.room.entity.QRoom;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RoomCondition {
+
+  private final QRoom room = QRoom.room;
+
+  public BooleanExpression existRoom() {
+    return new CaseBuilder()
+        .when(room.cafe.id.countDistinct().goe(1))
+        .then(true)
+        .otherwise(false);
+  }
+
+  public BooleanExpression existRoom(boolean existRoom) {
+    if (!existRoom) {
+      return null;
+    }
+
+    return room.cafe.id.countDistinct().goe(1);
+  }
+}

--- a/src/main/java/com/sparta/kidscafe/domain/cafe/service/CafeService.java
+++ b/src/main/java/com/sparta/kidscafe/domain/cafe/service/CafeService.java
@@ -1,8 +1,11 @@
 package com.sparta.kidscafe.domain.cafe.service;
 
+import com.sparta.kidscafe.common.dto.PageResponseDto;
 import com.sparta.kidscafe.common.dto.StatusDto;
 import com.sparta.kidscafe.common.util.FileUtil;
+import com.sparta.kidscafe.domain.cafe.dto.SearchCondition;
 import com.sparta.kidscafe.domain.cafe.dto.request.CafeCreateRequestDto;
+import com.sparta.kidscafe.domain.cafe.dto.response.CafeResponseDto;
 import com.sparta.kidscafe.domain.cafe.entity.Cafe;
 import com.sparta.kidscafe.domain.cafe.entity.CafeImage;
 import com.sparta.kidscafe.domain.cafe.repository.CafeImageRepository;
@@ -25,6 +28,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Service
 @RequiredArgsConstructor
 public class CafeService {
+
   private final CafeRepository cafeRepository;
   private final CafeImageRepository cafeImageRepository;
   private final RoomRepository roomRepository;
@@ -33,11 +37,19 @@ public class CafeService {
   private final FileUtil fileUtil;
 
   @Transactional
-  public StatusDto createCafe(User user, CafeCreateRequestDto requestDto, List<MultipartFile> cafeImages) {
+  public StatusDto createCafe(User user, CafeCreateRequestDto requestDto,
+      List<MultipartFile> cafeImages) {
     Cafe cafe = saveCafe(requestDto, user);
     saveCafeImage(cafe, cafeImages);
     saveCafeDetailInfo(requestDto, cafe);
-    return createStatusDto(HttpStatus.CREATED, "["+ cafe.getName() + "] 등록 성공");
+    return createStatusDto(HttpStatus.CREATED, "[" + cafe.getName() + "] 등록 성공");
+  }
+
+  public PageResponseDto<CafeResponseDto> searchCafe(SearchCondition condition) {
+    return PageResponseDto.success(
+        cafeRepository.searchCafe(condition),
+        HttpStatus.OK,
+        "카페 조회 성공");
   }
 
   private Cafe saveCafe(CafeCreateRequestDto requestDto, User user) {
@@ -49,7 +61,7 @@ public class CafeService {
   private void saveCafeImage(Cafe cafe, List<MultipartFile> cafeImages) {
     List<String> imagePaths = fileUtil.uploadCafeImage(cafeImages, cafe.getId());
     List<CafeImage> saveImages = new ArrayList<>();
-    for(String imagePath : imagePaths) {
+    for (String imagePath : imagePaths) {
       CafeImage cafeImage = CafeImage.builder()
           .cafe(cafe)
           .imagePath(imagePath)

--- a/src/main/resources/sql/test.sql
+++ b/src/main/resources/sql/test.sql
@@ -1,0 +1,88 @@
+# select c.id,
+         #        c.name,
+          #        c.size,
+          #        avg(re.star) as star,
+#        count(re.id) as count,
+#        case when count(ro.id) > 0 then true else false end as roomExist,
+#        c.parking,
+#        c.restaurant,
+#        c.opened_at,
+#        c.closed_at
+# from cafe as c left join review as re on c.id = re.cafe_id
+#      left join room as ro on c.id = ro.cafe_id
+#      left join fee as f on c.id = f.cafe_id
+# where star >= 2.0 and star < 3.0
+# group by c.id
+# order by star desc;
+
+select count(id)
+from room
+group by cafe_id;
+
+select *
+from cafe
+where id = 81;
+# 목, 일, 수, 토
+select c.id,
+       c.name,
+       c.address,
+       c.size,
+       avg(re.star),
+       COUNT(DISTINCT re.id),
+       case
+           when (COUNT(DISTINCT ro.id) >= 1)
+               then abs(sign(1))
+           else false
+           end,
+       c.parking,
+       c.restaurant,
+       c.opened_at,
+       c.closed_at
+from cafe c
+         left join review re on re.cafe_id = c.id
+         left join room ro on ro.cafe_id = c.id
+         left join fee f on f.cafe_id = c.id
+where c.size <= 500000
+  and c.parking = false
+  and (
+    c.day_off like '%일%' escape '!'
+        and c.opened_at >= '00:00'
+        and c.opened_at <= '23:59'
+    )
+  and c.restaurant = true
+  and c.multi_family = false
+  and c.opened_at >= '00:00'
+  and c.opened_at <= '01:30'
+group by c.id
+having avg(re.star) between 0.0 and 5.0
+order by avg(re.star);
+# limit ?, ?
+
+select c.id,
+       c.name,
+       c.address,
+       c.size,
+       avg(re.star),
+       count(distinct re.id),
+       case
+           when (count(distinct ro.cafe_id) >= 1)
+               then abs(sign(1))
+           else 0
+           end,
+       c.parking,
+       c.restaurant,
+       c.opened_at,
+       c.closed_at
+from cafe c
+         left join review re on re.cafe_id = c.id
+         left join room ro on ro.cafe_id = c.id
+         left join fee f on f.cafe_id = c.id
+where c.size <= 500000
+  and c.parking = false
+  and c.restaurant = true
+  and c.multi_family = false
+  and c.opened_at >= '00:00'
+  and c.closed_at <= '23:59'
+group by c.id
+having avg(re.star) between 0.0 and 5.0
+order by avg(re.star)

--- a/src/test/java/com/sparta/kidscafe/KidscafeApplicationTests.java
+++ b/src/test/java/com/sparta/kidscafe/KidscafeApplicationTests.java
@@ -9,5 +9,4 @@ class KidscafeApplicationTests {
     @Test
     void contextLoads() {
     }
-
 }

--- a/src/test/java/com/sparta/kidscafe/domain/cafe/dummy/CafeDummyTest.java
+++ b/src/test/java/com/sparta/kidscafe/domain/cafe/dummy/CafeDummyTest.java
@@ -54,7 +54,7 @@ public class CafeDummyTest {
   @Transactional
   @Rollback(false)
   void createCafe() {
-    //  user dummy test 돌려야함ds
+    //  user dummy test 돌려야함
     List<User> owners = userRepository.findAllByRole(RoleType.OWNER);
     for (User owner : owners) {
       List<Cafe> cafes = DummyCafe.createDummyCafes(owner, 10);
@@ -64,7 +64,7 @@ public class CafeDummyTest {
         List<CafeImage> cafeImages = DummyCafeImage.createDummyCafeImages(cafe, 5);
         cafeImageRepository.saveAll(cafeImages);
 
-        List<Room> rooms = DummyRoom.createDummyRooms(cafe, 5);
+        List<Room> rooms = DummyRoom.createDummyRooms(cafe, TestUtil.getRandomInteger(0, 5));
         roomRepository.saveAll(rooms);
 
         List<Fee> fees = DummyFee.createDummyFees(cafe);
@@ -72,15 +72,19 @@ public class CafeDummyTest {
 
         Collections.shuffle(rooms);
         Collections.shuffle(fees);
+
         List<PricePolicy> pricePolicies = DummyPricePolicy
             .createDummyPricePoliciesByFee(
                 cafe,
                 fees.subList(0, TestUtil.getRandomInteger(1, fees.size())));
-        pricePolicies.addAll(
-            DummyPricePolicy
-                .createDummyPricePoliciesByRoom(
-                    cafe,
-                    rooms.subList(0, TestUtil.getRandomInteger(1, rooms.size()))));
+        if(!rooms.isEmpty()) {
+          pricePolicies.addAll(
+              DummyPricePolicy
+                  .createDummyPricePoliciesByRoom(
+                      cafe,
+                      rooms.subList(0, TestUtil.getRandomInteger(1, rooms.size()))));
+        }
+
         pricePolicyRepository.saveAll(pricePolicies);
       }
     }


### PR DESCRIPTION
## 🔘 담당 파트
- 카페 리스트 조회 (사용자가 검색한)

## 🔎 작업 상세 내용
- 사용자가 다양한 검색조건을 사용하여 카페를 검색할 수 있다.
- 페이징 처리되어 반환된다.
- querydsl을 사용하여 조회 build.gradle에 필요한 것들 추가
- 테스트 코드 추가
- HeaderTokenValidFilter isApplicable함수에 인증처리를 하지않는 url추가
- PageResponseDto null처리 관련 보완
- 테스트용 쿼리 파일 test.sql 추가

## 🔧 앞으로의 과제
-  카페 등록(admin)
- 카페 리스트 조회(관리자 검색한)
- 카페 리스트 조회(사장님이 등록한)
- 카페 상세 조회
- 카페 수정
- 카페 삭제(ADMIN)
- 카페 삭제(OWNER)

## ➕ 이슈 링크
- #43