### PR TITLE
feat: 가격 정책 삭제 기능 구현 #39

### DIFF
--- a/src/main/java/com/sparta/kidscafe/domain/pricepolicy/controller/PricePolicyController.java
+++ b/src/main/java/com/sparta/kidscafe/domain/pricepolicy/controller/PricePolicyController.java
@@ -43,4 +43,12 @@ public class PricePolicyController {
         return ResponseEntity.ok("가격 정책이 수정되었습니다.");
     }
 
+    @DeleteMapping("/{pricesId}")
+    public ResponseEntity<String> deletePricePolicy(
+            @PathVariable Long cafeId,
+            @PathVariable Long pricesId
+    ) {
+        pricePolicyService.deletePricePolicy(cafeId, pricesId);
+        return ResponseEntity.ok("가격 정책이 삭제되었습니다.");
+    }
 }

--- a/src/main/java/com/sparta/kidscafe/domain/pricepolicy/service/PricePolicyService.java
+++ b/src/main/java/com/sparta/kidscafe/domain/pricepolicy/service/PricePolicyService.java
@@ -75,4 +75,23 @@ public class PricePolicyService {
         // 4. 업데이트
         pricePolicy.updateDetails(requestDto.getTargetId(), requestDto.getDayType(), requestDto.getRate());
     }
+
+    @Transactional
+    public void deletePricePolicy(Long cafeId, Long pricePolicyId) {
+        // 1. Cafe 조회
+        Cafe cafe = cafeRepository.findById(cafeId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CAFE_NOT_FOUND));
+
+        // 2. PricePolicy 조회
+        PricePolicy pricePolicy = pricePolicyRepository.findById(pricePolicyId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PRICE_POLICY_NOT_FOUND));
+
+        // 3. 동일 Cafe 소속인지 검증
+        if (!pricePolicy.getCafe().equals(cafe)) {
+            throw new BusinessException(ErrorCode.PRICE_POLICY_MISMATCH);
+        }
+
+        // 4. 삭제
+        pricePolicyRepository.delete(pricePolicy);
+    }
 }


### PR DESCRIPTION
🐧🩷작업 내용
**1. 가격 정책 삭제 API 추가**
- URL: /api/cafes/{cafeId}/prices/{pricesId}
- HTTP Method: DELETE
- 요청받은 cafeId와 pricesId를 기반으로 가격 정책 삭제 처리
- 삭제 성공 시 "가격 정책이 삭제되었습니다." 메시지를 반환

**2. PricePolicyController 수정**
- @DeleteMapping("/{pricesId}") 추가
- PricePolicyService의 deletePricePolicy 호출로 삭제 처리

**3. PricePolicyService 수정**
- deletePricePolicy(Long cafeId, Long pricePolicyId) 메서드 추가
- Cafe와 PricePolicy의 존재 여부 및 관계를 검증 후 삭제 처리
- 검증 실패 시 BusinessException 발생

**4. Postman을 통해 삭제 API 테스트 완료**
- 성공 시: 200 OK 응답과 삭제 성공 메시지 반환 확인
- 예외 시: 올바른 에러 메시지와 HTTP 상태 코드 반환 확인
(존재하지 않는 cafeId 또는 pricesId 요청 시 404 에러 반환, 카페와 관련 없는 가격 정책 요청 시 400 에러 반환)


@gaeul79 @Dohyeon-Parrk @gyeonwoo-jerry @dameun0527 