### PR TITLE
즐겨찾기 조회(카페용) 기능 구현

### DIFF
--- a/src/main/java/com/sparta/kidscafe/domain/bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/sparta/kidscafe/domain/bookmark/controller/BookmarkController.java
@@ -7,7 +7,6 @@ import com.sparta.kidscafe.common.dto.StatusDto;
 import com.sparta.kidscafe.domain.bookmark.dto.response.BookmarkOwnerRetreiveResponseDto;
 import com.sparta.kidscafe.domain.bookmark.dto.response.BookmarkUserRetreiveResponseDto;
 import com.sparta.kidscafe.domain.bookmark.service.BookmarkService;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/sparta/kidscafe/domain/bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/sparta/kidscafe/domain/bookmark/controller/BookmarkController.java
@@ -4,6 +4,7 @@ import com.sparta.kidscafe.common.annotation.Auth;
 import com.sparta.kidscafe.common.dto.AuthUser;
 import com.sparta.kidscafe.common.dto.PageResponseDto;
 import com.sparta.kidscafe.common.dto.StatusDto;
+import com.sparta.kidscafe.domain.bookmark.dto.response.BookmarkOwnerRetreiveResponseDto;
 import com.sparta.kidscafe.domain.bookmark.dto.response.BookmarkUserRetreiveResponseDto;
 import com.sparta.kidscafe.domain.bookmark.service.BookmarkService;
 import jakarta.validation.Valid;
@@ -28,7 +29,7 @@ public class BookmarkController {
   @PostMapping("/cafes/{cafeId}/bookmarks")
   public ResponseEntity<StatusDto> toggleBookmark(
       @Auth AuthUser authUser,
-      @Valid @PathVariable(value = "cafeId") Long cafeId) {
+      @PathVariable(value = "cafeId") Long cafeId) {
 
     boolean isBookmarked = bookmarkService.toggleBookmark(authUser.getId(), cafeId);
 
@@ -42,12 +43,25 @@ public class BookmarkController {
 
   // 즐겨찾기 조회(User용)
   @GetMapping("/users/bookmarks")
-  public ResponseEntity<PageResponseDto<BookmarkUserRetreiveResponseDto>> getBookmarks(
+  public ResponseEntity<PageResponseDto<BookmarkUserRetreiveResponseDto>> getBookmarksByUser(
       @Auth AuthUser authUser,
       @RequestParam(defaultValue = "0") int page,
       @RequestParam(defaultValue = "10") int size) {
-    PageResponseDto<BookmarkUserRetreiveResponseDto> response = bookmarkService.getBookmark(
-        authUser.getId(), page, size);
+    PageResponseDto<BookmarkUserRetreiveResponseDto> response = bookmarkService.getBookmarkByUser(
+        authUser, page, size);
     return ResponseEntity.ok(response);
   }
+
+  // 즐겨찾기 조회(Owner용)
+  @GetMapping("/owners/bookmarks/{cafeId}")
+  public ResponseEntity<PageResponseDto<BookmarkOwnerRetreiveResponseDto>> getBookmarksByOwner(
+      @Auth AuthUser authUser,
+      @PathVariable Long cafeId,
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "10") int size) {
+    PageResponseDto<BookmarkOwnerRetreiveResponseDto> response = bookmarkService.getBookmarkByOwner(
+        authUser, cafeId, page, size);
+    return ResponseEntity.ok(response);
+  }
+
 }

--- a/src/main/java/com/sparta/kidscafe/domain/bookmark/dto/response/BookmarkOwnerRetreiveResponseDto.java
+++ b/src/main/java/com/sparta/kidscafe/domain/bookmark/dto/response/BookmarkOwnerRetreiveResponseDto.java
@@ -1,0 +1,17 @@
+package com.sparta.kidscafe.domain.bookmark.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class BookmarkOwnerRetreiveResponseDto {
+
+  private Long userId;
+  private String userName;
+
+  public BookmarkOwnerRetreiveResponseDto(Long userId, String userName) {
+    this.userId = userId;
+    this.userName = userName;
+  }
+}

--- a/src/main/java/com/sparta/kidscafe/domain/bookmark/dto/response/BookmarkUserRetreiveResponseDto.java
+++ b/src/main/java/com/sparta/kidscafe/domain/bookmark/dto/response/BookmarkUserRetreiveResponseDto.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class BookmarkUserRetreiveResponseDto {
+
   private Long cafeId;
   private String cafeName;
 
@@ -13,7 +14,6 @@ public class BookmarkUserRetreiveResponseDto {
     this.cafeId = cafeId;
     this.cafeName = cafeName;
   }
-
 
 
 }

--- a/src/main/java/com/sparta/kidscafe/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/com/sparta/kidscafe/domain/bookmark/entity/Bookmark.java
@@ -3,8 +3,6 @@ package com.sparta.kidscafe.domain.bookmark.entity;
 import com.sparta.kidscafe.common.entity.Timestamped;
 import com.sparta.kidscafe.domain.cafe.entity.Cafe;
 import com.sparta.kidscafe.domain.user.entity.User;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;

--- a/src/main/java/com/sparta/kidscafe/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/sparta/kidscafe/domain/bookmark/repository/BookmarkRepository.java
@@ -15,4 +15,6 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
   Optional<Bookmark> findByUserAndCafe(User user, Cafe cafe);
 
   Page<Bookmark> findAllByUserId(Long userId, Pageable pageable);
+
+  Page<Bookmark> findAllByCafeId(Long cafeId, Pageable pageable);
 }

--- a/src/test/java/com/sparta/kidscafe/domain/bookmark/service/BookmarkServiceTest.java
+++ b/src/test/java/com/sparta/kidscafe/domain/bookmark/service/BookmarkServiceTest.java
@@ -2,13 +2,17 @@ package com.sparta.kidscafe.domain.bookmark.service;
 
 import static org.hibernate.validator.internal.util.Contracts.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.sparta.kidscafe.common.dto.AuthUser;
 import com.sparta.kidscafe.common.dto.PageResponseDto;
 import com.sparta.kidscafe.common.enums.RoleType;
+import com.sparta.kidscafe.domain.bookmark.dto.response.BookmarkOwnerRetreiveResponseDto;
 import com.sparta.kidscafe.domain.bookmark.dto.response.BookmarkUserRetreiveResponseDto;
 import com.sparta.kidscafe.domain.bookmark.entity.Bookmark;
 import com.sparta.kidscafe.domain.bookmark.repository.BookmarkRepository;
@@ -21,6 +25,7 @@ import com.sparta.kidscafe.exception.ErrorCode;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -51,6 +56,15 @@ public class BookmarkServiceTest {
   @Mock
   private UserRepository userRepository;
 
+  private AuthUser authUser;
+  private Pageable pageable;
+
+  @BeforeEach
+  void setUp() {
+    authUser = new AuthUser(1L, "Test@example.com", RoleType.USER);
+    pageable = PageRequest.of(0, 10, Sort.by(Direction.DESC, "createdAt"));
+  }
+
   @Test
   @DisplayName("즐겨찾기 추가: 성공")
   void addToggleBookmark_success() {
@@ -58,25 +72,20 @@ public class BookmarkServiceTest {
     Long userId = 1L;
     Long cafeId = 1L;
 
-    User user = new User();
-    Cafe cafe = new Cafe();
+    User user = new User(userId, "Test@Example.com", RoleType.USER);
+    Cafe cafe = new Cafe(cafeId, "Test Cafe");
 
-    Mockito.when(userRepository.findById(userId))
-        .thenReturn(Optional.of(user));
-    Mockito.when(cafeRepository.findById(cafeId))
-        .thenReturn(Optional.of(cafe));
-    Mockito.when(bookmarkRepository.findByUserAndCafe(user, cafe))
-        .thenReturn(Optional.empty());
+    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    when(cafeRepository.findById(cafeId)).thenReturn(Optional.of(cafe));
+    when(bookmarkRepository.findByUserAndCafe(user, cafe)).thenReturn(Optional.empty());
 
     // When
     boolean result = bookmarkService.toggleBookmark(userId, cafeId);
 
     // Then
     Assertions.assertTrue(result);
-    Mockito.verify(bookmarkRepository, Mockito.times(1))
-        .save(Mockito.any(Bookmark.class));
-    Mockito.verify(bookmarkRepository, Mockito.never())
-        .delete(Mockito.any(Bookmark.class));
+    verify(bookmarkRepository, Mockito.times(1)).save(any(Bookmark.class));
+    verify(bookmarkRepository, Mockito.never()).delete(any(Bookmark.class));
   }
 
   @Test
@@ -86,40 +95,29 @@ public class BookmarkServiceTest {
     Long userId = 1L;
     Long cafeId = 1L;
 
-    User user = new User();
-    Cafe cafe = new Cafe();
-    Bookmark bookmark = new Bookmark();
+    User user = new User(userId, "Test@Example.com", RoleType.USER);
+    Cafe cafe = new Cafe(cafeId, "Test Cafe");
+    Bookmark bookmark = new Bookmark(1L, user, cafe);
 
-    Mockito.when(userRepository.findById(userId))
-        .thenReturn(Optional.of(user));
-    Mockito.when(cafeRepository.findById(cafeId))
-        .thenReturn(Optional.of(cafe));
-    Mockito.when(bookmarkRepository.findByUserAndCafe(user, cafe))
-        .thenReturn(Optional.of(bookmark));
+    when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+    when(cafeRepository.findById(cafeId)).thenReturn(Optional.of(cafe));
+    when(bookmarkRepository.findByUserAndCafe(user, cafe)).thenReturn(Optional.of(bookmark));
 
     // When
     boolean result = bookmarkService.toggleBookmark(userId, cafeId);
 
     // Then
-    Assertions.assertFalse(result);
-    Mockito.verify(bookmarkRepository, Mockito.times(1))
-        .delete(bookmark);
-    Mockito.verify(bookmarkRepository, Mockito.never())
-        .save(Mockito.any(Bookmark.class));
+    assertFalse(result);
+    verify(bookmarkRepository, Mockito.times(1)).delete(bookmark);
+    verify(bookmarkRepository, Mockito.never()).save(any(Bookmark.class));
   }
 
   @Test
   @DisplayName("사용자 전용 즐겨찾기 조회: 성공")
-  void getBookmark_success() {
+  void getBookmarkByUser_success() {
     // Given
-    Long userId = 1L;
     int page = 0;
     int size = 10;
-
-    User user = User.builder()
-        .id(userId)
-        .role(RoleType.USER)
-        .build();
 
     List<Bookmark> bookmarks = List.of(
         Bookmark.builder()
@@ -129,15 +127,13 @@ public class BookmarkServiceTest {
             .cafe(Cafe.builder().id(102L).name("Cafe B").build())
             .build()
     );
-    Page<Bookmark> mockPage = new PageImpl<>(bookmarks, PageRequest.of(page, size),
-        bookmarks.size());
+    Page<Bookmark> mockPage = new PageImpl<>(bookmarks, pageable, bookmarks.size());
 
-    Mockito.when(userRepository.findById(userId)).thenReturn(Optional.of(user));
-    Mockito.when(bookmarkRepository.findAllByUserId(userId, PageRequest.of(page, size, Sort.by(
-        Direction.DESC, "createdAt")))).thenReturn(mockPage);
+    when(bookmarkRepository.findAllByUserId(eq(authUser.getId()), any(Pageable.class))).thenReturn(mockPage);
 
     // When
-    PageResponseDto<BookmarkUserRetreiveResponseDto> response = bookmarkService.getBookmark(userId,
+    PageResponseDto<BookmarkUserRetreiveResponseDto> response = bookmarkService.getBookmarkByUser(
+        authUser,
         page, size);
 
     // Then
@@ -154,49 +150,90 @@ public class BookmarkServiceTest {
   }
 
   @Test
-  @DisplayName("인증되지 않은 사용자가 즐겨찾기 조회를 시도한 경우")
-  void getBookmark_UserNotFound() {
+  @DisplayName("사용자 전용 즐겨찾기 조회: 실패 - 권한 없음")
+  void getBookmarkByUser_Unauthorized() {
     // Given
-    Long userId = 1L;
-    given(userRepository.findById(userId)).willReturn(Optional.empty());
+    AuthUser unauthorizedUser = new AuthUser(2L, "Test@example.com", RoleType.ADMIN);// 비권한 사용자
 
     // When & Then
     BusinessException ex = assertThrows(BusinessException.class, () ->
-        bookmarkService.getBookmark(userId, 0, 10)
-    );
-    assertEquals(ErrorCode.USER_NOT_FOUND, ex.getErrorCode());
-  }
-
-  @Test
-  @DisplayName("사용자(User) 권한이 없는 경우")
-  void getBookmark_Unauthorized() {
-    // Given
-    Long userId = 1L;
-    User user = new User(userId, "test@example.com", RoleType.ADMIN); // 비권한 사용자
-    given(userRepository.findById(userId)).willReturn(Optional.of(user));
-
-    // When & Then
-    BusinessException ex = assertThrows(BusinessException.class, () ->
-        bookmarkService.getBookmark(userId, 0, 10)
+        bookmarkService.getBookmarkByUser(unauthorizedUser, 0, 10)
     );
     assertEquals(ErrorCode.UNAUTHORIZED, ex.getErrorCode());
   }
 
   @Test
-  @DisplayName("즐겨찾기 목록이 비어있는 경우")
-  void getBookmark_NoBookmarks() {
+  @DisplayName("사용자 전용 즐겨찾기 조회: 실패 - 즐겨찾기 목록이 비어있는 경우")
+  void getBookmarkByUser_NoBookmarks() {
     // Given
-    Long userId = 1L;
-    User user = new User(userId, "test@example.com", RoleType.USER);
     Page<Bookmark> emptyPage = Page.empty();
-    given(userRepository.findById(userId)).willReturn(Optional.of(user));
-    given(bookmarkRepository.findAllByUserId(eq(userId), any(Pageable.class))).willReturn(
-        emptyPage);
-
+    when(bookmarkRepository.findAllByUserId(eq(authUser.getId()), any(Pageable.class))).thenReturn(emptyPage);
     // When & Then
     BusinessException ex = assertThrows(BusinessException.class, () ->
-        bookmarkService.getBookmark(userId, 0, 10)
+        bookmarkService.getBookmarkByUser(authUser, 0, 10)
     );
     assertEquals(ErrorCode.NO_BOOKMARKS_FOUND, ex.getErrorCode());
   }
+
+  @Test
+  @DisplayName("카페 전용 즐겨찾기 조회: 성공")
+  void getBookmarkByOwner_success() {
+    // Given
+    AuthUser ownerUser = new AuthUser(101L, "Test@example.com", RoleType.OWNER);
+    Long cafeId = 1L;
+    int page = 0;
+    int size = 10;
+
+    List<Bookmark> bookmarkList = List.of(
+        Bookmark.builder()
+            .user(User.builder().id(10L).name("Tester 1").role(RoleType.USER).build())
+            .cafe(Cafe.builder().id(1L).name("Cafe A").build())
+            .build(),
+        Bookmark.builder()
+            .user(User.builder().id(20L).name("Tester 2").role(RoleType.USER).build())
+            .cafe(Cafe.builder().id(1L).name("Cafe A").build())
+            .build()
+    );
+    Page<Bookmark> bookmarkPage = new PageImpl<>(bookmarkList, pageable, bookmarkList.size());
+
+    when(bookmarkRepository.findAllByCafeId(eq(cafeId), any(Pageable.class))).thenReturn(bookmarkPage);
+
+    // When
+    PageResponseDto<BookmarkOwnerRetreiveResponseDto> response =
+        bookmarkService.getBookmarkByOwner(ownerUser, cafeId, page, size);
+
+    // Then
+    assertNotNull(response);
+    assertEquals("즐겨찾기 조회(카페용) 성공", response.getMessage());
+    assertEquals(1, response.getPage());
+    assertEquals(10, response.getSize());
+    assertEquals(1, response.getTotalPage());
+
+    assertEquals(2, response.getData().size());
+
+    BookmarkOwnerRetreiveResponseDto response1Dto = response.getData().get(0);
+    assertEquals(10L, response1Dto.getUserId());
+    assertEquals("Tester 1", response1Dto.getUserName());
+
+    BookmarkOwnerRetreiveResponseDto response2Dto = response.getData().get(1);
+    assertEquals(20L, response2Dto.getUserId());
+    assertEquals("Tester 2", response2Dto.getUserName());
+  }
+
+  @Test
+  @DisplayName("카페 전용 즐겨찾기 조회: 실패 - 권한 없음")
+  void getBookmarkByOwner_unauthorized() {
+    // Given
+    Long cafeId = 1L;
+    int page = 0;
+    int size = 10;
+
+    // When & Then
+    BusinessException ex = assertThrows(
+        BusinessException.class, () -> bookmarkService.getBookmarkByOwner(authUser, cafeId, page, size)
+    );
+    assertEquals(ErrorCode.UNAUTHORIZED, ex.getErrorCode());
+  }
 }
+
+


### PR DESCRIPTION
### 시나리오
- `GET` `/api/owners/bookmarks/{cafeId}`

1. 카페 사장이 자신의 가게를 즐겨찾기 한 손님 목록 조회
2. 사장(OWNER)가 아닌 사용자(USER)인 경우 예외처리

### 단위 테스트 
- BookmarkServiceTest에서 진행

1. 카페 전용 즐겨찾기 조회 성공 케이스
2. 카페 사장(OWNER) 권한이 없는 경우

### 관련 이슈
#63 