### PR TITLE
Feat/70 카페 상세 조회

### DIFF
--- a/src/main/java/com/sparta/kidscafe/common/entity/Timestamped.java
+++ b/src/main/java/com/sparta/kidscafe/common/entity/Timestamped.java
@@ -28,5 +28,5 @@ public abstract class Timestamped {
   @LastModifiedDate
   @Column
   @Temporal(TemporalType.TIMESTAMP)
-  private LocalDateTime updatedAt;
+  private LocalDateTime modifiedAt;
 }

--- a/src/main/java/com/sparta/kidscafe/domain/cafe/controller/CafeController.java
+++ b/src/main/java/com/sparta/kidscafe/domain/cafe/controller/CafeController.java
@@ -1,9 +1,11 @@
 package com.sparta.kidscafe.domain.cafe.controller;
 
 import com.sparta.kidscafe.common.dto.PageResponseDto;
+import com.sparta.kidscafe.common.dto.ResponseDto;
 import com.sparta.kidscafe.common.dto.StatusDto;
 import com.sparta.kidscafe.domain.cafe.dto.request.CafeCreateRequestDto;
 import com.sparta.kidscafe.domain.cafe.dto.request.CafeSearchRequestDto;
+import com.sparta.kidscafe.domain.cafe.dto.response.CafeDetailResponseDto;
 import com.sparta.kidscafe.domain.cafe.dto.response.CafeResponseDto;
 import com.sparta.kidscafe.domain.cafe.service.CafeService;
 import com.sparta.kidscafe.domain.user.entity.User;
@@ -13,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -44,7 +47,17 @@ public class CafeController {
   public ResponseEntity<PageResponseDto<CafeResponseDto>> searchCafe(
       @Valid @RequestBody CafeSearchRequestDto requestDto
   ) {
-    return ResponseEntity.status(HttpStatus.OK)
+    return ResponseEntity
+        .status(HttpStatus.OK)
         .body(cafeService.searchCafe(requestDto.getSearchCondition()));
+  }
+
+  @GetMapping("/cafes/{cafeId}")
+  public ResponseEntity<ResponseDto<CafeDetailResponseDto>> getCafe(
+      @PathVariable Long cafeId
+  ) {
+    return ResponseEntity
+        .status(HttpStatus.OK)
+        .body(cafeService.getCafe(cafeId));
   }
 }

--- a/src/main/java/com/sparta/kidscafe/domain/cafe/controller/CafeController.java
+++ b/src/main/java/com/sparta/kidscafe/domain/cafe/controller/CafeController.java
@@ -1,5 +1,7 @@
 package com.sparta.kidscafe.domain.cafe.controller;
 
+import com.sparta.kidscafe.common.annotation.Auth;
+import com.sparta.kidscafe.common.dto.AuthUser;
 import com.sparta.kidscafe.common.dto.PageResponseDto;
 import com.sparta.kidscafe.common.dto.ResponseDto;
 import com.sparta.kidscafe.common.dto.StatusDto;
@@ -32,15 +34,13 @@ public class CafeController {
 
   @PostMapping("/owners/cafes")
   public ResponseEntity<StatusDto> createCafe(
-      // TODO khj [인증/인가] 완료되면 교체할 것.
+      @Auth AuthUser authUser,
       @Valid @RequestPart CafeCreateRequestDto requestDto,
       @RequestPart List<MultipartFile> cafeImages
   ) {
-    // TODO khj [인증/인가] 완료되면 교체할 것.
-    User user = User.builder().id(15L).build();
     return ResponseEntity
         .status(HttpStatus.CREATED)
-        .body(cafeService.createCafe(user, requestDto, cafeImages));
+        .body(cafeService.createCafe(authUser, requestDto, cafeImages));
   }
 
   @GetMapping("/cafes")

--- a/src/main/java/com/sparta/kidscafe/domain/cafe/controller/CafeController.java
+++ b/src/main/java/com/sparta/kidscafe/domain/cafe/controller/CafeController.java
@@ -10,7 +10,6 @@ import com.sparta.kidscafe.domain.cafe.dto.request.CafeSearchRequestDto;
 import com.sparta.kidscafe.domain.cafe.dto.response.CafeDetailResponseDto;
 import com.sparta.kidscafe.domain.cafe.dto.response.CafeResponseDto;
 import com.sparta.kidscafe.domain.cafe.service.CafeService;
-import com.sparta.kidscafe.domain.user.entity.User;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -58,6 +57,6 @@ public class CafeController {
   ) {
     return ResponseEntity
         .status(HttpStatus.OK)
-        .body(cafeService.getCafe(cafeId));
+        .body(cafeService.findCafe(cafeId));
   }
 }

--- a/src/main/java/com/sparta/kidscafe/domain/cafe/dto/request/CafeCreateRequestDto.java
+++ b/src/main/java/com/sparta/kidscafe/domain/cafe/dto/request/CafeCreateRequestDto.java
@@ -10,6 +10,7 @@ import com.sparta.kidscafe.domain.room.entity.Room;
 import com.sparta.kidscafe.domain.user.entity.User;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
 import java.time.LocalTime;
 import java.util.ArrayList;
@@ -38,6 +39,11 @@ public class CafeCreateRequestDto {
   private int size;
 
   private boolean multiFamily;
+
+  @Pattern(
+      regexp = "^(월|화|수|목|금|토|일)(,\\s*(월|화|수|목|금|토|일))*$",
+      message = "DayType은 요일을 쉼표로 구분하여 입력해야 합니다. (예: '월, 화, 수')"
+  )
   private String dayOff;
   private boolean parking;
   private boolean restaurant;

--- a/src/main/java/com/sparta/kidscafe/domain/cafe/dto/response/CafeDetailResponseDto.java
+++ b/src/main/java/com/sparta/kidscafe/domain/cafe/dto/response/CafeDetailResponseDto.java
@@ -1,0 +1,88 @@
+package com.sparta.kidscafe.domain.cafe.dto.response;
+
+import com.sparta.kidscafe.domain.cafe.entity.CafeImage;
+import com.sparta.kidscafe.domain.fee.dto.response.FeeResponseDto;
+import com.sparta.kidscafe.domain.fee.entity.Fee;
+import com.sparta.kidscafe.domain.pricepolicy.dto.response.PricePolicyResponseDto;
+import com.sparta.kidscafe.domain.pricepolicy.entity.PricePolicy;
+import com.sparta.kidscafe.domain.room.dto.response.RoomResponseDto;
+import com.sparta.kidscafe.domain.room.entity.Room;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CafeDetailResponseDto {
+
+  private Long id;
+  private String name;
+  private String address;
+  private int size;
+  private double star;
+  private Long reviewCount;
+  private boolean multiFamily;
+  private boolean existRoom;
+  private String dayOff;
+  private boolean parking;
+  private boolean existRestaurant;
+  private String hyperLink;
+  private LocalTime openedAt;
+  private LocalTime closedAt;
+
+  private List<CafeImageResponseDto> images;
+  private List<RoomResponseDto> rooms;
+  private List<FeeResponseDto> fees;
+  private List<PricePolicyResponseDto> pricePolicies;
+
+  public void setCafeInfo(CafeResponseDto cafeInfo) {
+    id = cafeInfo.getId();
+    name = cafeInfo.getName();
+    address = cafeInfo.getAddress();
+    size = cafeInfo.getSize();
+    star = cafeInfo.getStar();
+    reviewCount = cafeInfo.getReviewCount();
+    multiFamily = cafeInfo.isMultiFamily();
+    existRoom = cafeInfo.isExistRoom();
+    dayOff = cafeInfo.getDayOff();
+    parking = cafeInfo.isParking();
+    existRestaurant = cafeInfo.isExistRestaurant();
+    hyperLink = cafeInfo.getHyperLink();
+    openedAt = cafeInfo.getOpenedAt();
+    closedAt = cafeInfo.getClosedAt();
+  }
+
+  public void setCafeImage(List<CafeImage> images) {
+    this.images = new ArrayList<>();
+    for (CafeImage image : images) {
+      this.images.add(CafeImageResponseDto.from(image));
+    }
+  }
+
+  public void setRooms(List<Room> rooms) {
+    this.rooms = new ArrayList<>();
+    for (Room room : rooms) {
+      this.rooms.add(RoomResponseDto.from(room));
+    }
+  }
+
+  public void setFees(List<Fee> fees) {
+    this.fees = new ArrayList<>();
+    for (Fee fee : fees) {
+      this.fees.add(FeeResponseDto.from(fee));
+    }
+  }
+
+  public void setPricePolicies(List<PricePolicy> pricePolicies) {
+    this.pricePolicies = new ArrayList<>();
+    for (PricePolicy pricePolicy : pricePolicies) {
+      this.pricePolicies.add(PricePolicyResponseDto.from(pricePolicy));
+    }
+  }
+}

--- a/src/main/java/com/sparta/kidscafe/domain/cafe/dto/response/CafeImageResponseDto.java
+++ b/src/main/java/com/sparta/kidscafe/domain/cafe/dto/response/CafeImageResponseDto.java
@@ -1,0 +1,28 @@
+package com.sparta.kidscafe.domain.cafe.dto.response;
+
+import com.sparta.kidscafe.domain.cafe.entity.CafeImage;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CafeImageResponseDto {
+  private Long id;
+  private String imagePath;
+  private LocalDateTime createdAt;
+  private LocalDateTime modifiedAt;
+
+  public static CafeImageResponseDto from(CafeImage cafeImage) {
+    return CafeImageResponseDto.builder()
+        .id(cafeImage.getId())
+        .imagePath(cafeImage.getImagePath())
+        .createdAt(cafeImage.getCreatedAt())
+        .modifiedAt(cafeImage.getModifiedAt())
+        .build();
+  }
+}

--- a/src/main/java/com/sparta/kidscafe/domain/cafe/dto/response/CafeResponseDto.java
+++ b/src/main/java/com/sparta/kidscafe/domain/cafe/dto/response/CafeResponseDto.java
@@ -2,11 +2,9 @@ package com.sparta.kidscafe.domain.cafe.dto.response;
 
 import com.querydsl.core.annotations.QueryProjection;
 import java.time.LocalTime;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Builder
 @Getter
 @NoArgsConstructor
 public class CafeResponseDto {
@@ -17,9 +15,12 @@ public class CafeResponseDto {
   private int size;
   private double star;
   private Long reviewCount;
+  private String dayOff;
+  private boolean multiFamily;
   private boolean existRoom;
   private boolean parking;
-  private boolean restaurantExists;
+  private boolean existRestaurant;
+  private String hyperLink;
   private LocalTime openedAt;
   private LocalTime closedAt;
 
@@ -31,9 +32,12 @@ public class CafeResponseDto {
       int size,
       double star,
       Long reviewCount,
-      boolean existRoom, // boolean
+      String dayOff,
+      boolean multiFamily,
+      boolean existRoom,
       boolean parking,
-      boolean restaurantExists,
+      boolean existRestaurant,
+      String hyperLink,
       LocalTime openedAt,
       LocalTime closedAt) {
     this.id = id;
@@ -42,9 +46,12 @@ public class CafeResponseDto {
     this.size = size;
     this.star = star;
     this.reviewCount = reviewCount;
+    this.dayOff = dayOff;
+    this.multiFamily = multiFamily;
     this.existRoom = existRoom;
     this.parking = parking;
-    this.restaurantExists = restaurantExists;
+    this.existRestaurant = existRestaurant;
+    this.hyperLink = hyperLink;
     this.openedAt = openedAt;
     this.closedAt = closedAt;
   }

--- a/src/main/java/com/sparta/kidscafe/domain/cafe/enums/SearchSortBy.java
+++ b/src/main/java/com/sparta/kidscafe/domain/cafe/enums/SearchSortBy.java
@@ -17,9 +17,9 @@ public enum SearchSortBy {
 
   @JsonCreator
   public static SearchSortBy getAgeGroup(String name) {
-    for (SearchSortBy ageGroup : SearchSortBy.values()) {
-      if (ageGroup.toString().equals(name)) {
-        return ageGroup;
+    for (SearchSortBy sortBy : SearchSortBy.values()) {
+      if (sortBy.toString().equals(name)) {
+        return sortBy;
       }
     }
     return CAFE_NAME;

--- a/src/main/java/com/sparta/kidscafe/domain/cafe/repository/CafeDslRepository.java
+++ b/src/main/java/com/sparta/kidscafe/domain/cafe/repository/CafeDslRepository.java
@@ -5,5 +5,8 @@ import com.sparta.kidscafe.domain.cafe.dto.response.CafeResponseDto;
 import org.springframework.data.domain.Page;
 
 public interface CafeDslRepository {
+
+  CafeResponseDto findCafeById(Long id);
+
   Page<CafeResponseDto> searchCafe(SearchCondition condition);
 }

--- a/src/main/java/com/sparta/kidscafe/domain/cafe/repository/CafeDslRepository.java
+++ b/src/main/java/com/sparta/kidscafe/domain/cafe/repository/CafeDslRepository.java
@@ -8,5 +8,5 @@ public interface CafeDslRepository {
 
   CafeResponseDto findCafeById(Long id);
 
-  Page<CafeResponseDto> searchCafe(SearchCondition condition);
+  Page<CafeResponseDto> findAllByCafe(SearchCondition condition);
 }

--- a/src/main/java/com/sparta/kidscafe/domain/cafe/repository/CafeDslRepositoryImpl.java
+++ b/src/main/java/com/sparta/kidscafe/domain/cafe/repository/CafeDslRepositoryImpl.java
@@ -46,7 +46,7 @@ public class CafeDslRepositoryImpl implements CafeDslRepository {
   }
 
   @Override
-  public Page<CafeResponseDto> searchCafe(SearchCondition condition) {
+  public Page<CafeResponseDto> findAllByCafe(SearchCondition condition) {
     long cntTotal = searchCafeTotalCount(condition);
     if (cntTotal == 0) {
       return Page.empty();

--- a/src/main/java/com/sparta/kidscafe/domain/cafe/repository/CafeDslRepositoryImpl.java
+++ b/src/main/java/com/sparta/kidscafe/domain/cafe/repository/CafeDslRepositoryImpl.java
@@ -1,13 +1,17 @@
 package com.sparta.kidscafe.domain.cafe.repository;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.ComparableExpressionBase;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.sparta.kidscafe.domain.cafe.dto.SearchCondition;
 import com.sparta.kidscafe.domain.cafe.dto.response.CafeResponseDto;
 import com.sparta.kidscafe.domain.cafe.dto.response.QCafeResponseDto;
 import com.sparta.kidscafe.domain.cafe.entity.QCafe;
+import com.sparta.kidscafe.domain.cafe.enums.SearchSortBy;
 import com.sparta.kidscafe.domain.cafe.repository.condition.CafeCondition;
 import com.sparta.kidscafe.domain.cafe.repository.condition.FeeCondition;
 import com.sparta.kidscafe.domain.cafe.repository.condition.ReviewCondition;
@@ -34,32 +38,25 @@ public class CafeDslRepositoryImpl implements CafeDslRepository {
   private final QFee fee = new QFee("fee");
 
   @Override
+  public CafeResponseDto findCafeById(Long id) {
+    return baseCafeQuery()
+        .where(cafe.id.eq(id))
+        .groupBy(cafe.id)
+        .fetchFirst();
+  }
+
+  @Override
   public Page<CafeResponseDto> searchCafe(SearchCondition condition) {
     long cntTotal = searchCafeTotalCount(condition);
     if (cntTotal == 0) {
       return Page.empty();
     }
 
-    List<CafeResponseDto> cafes = queryFactory.select(new QCafeResponseDto(
-            cafe.id,
-            cafe.name,
-            cafe.address,
-            cafe.size,
-            review.star.avg(),
-            review.id.countDistinct(),
-            roomCondition.existRoom(),
-            cafe.parking,
-            cafe.restaurant,
-            cafe.openedAt,
-            cafe.closedAt))
-        .from(cafe)
-        .leftJoin(review).on(review.cafe.eq(cafe))
-        .leftJoin(room).on(room.cafe.eq(cafe))
+    List<CafeResponseDto> cafes = baseCafeQuery()
         .leftJoin(fee).on(fee.cafe.eq(cafe))
         .where(makeWhere(condition))
         .groupBy(cafe.id)
         .having(makeHaving(condition))
-        .orderBy(makeOrderBy(condition))
         .limit(condition.getPageable().getPageSize())
         .offset(condition.getPageable().getOffset())
         .fetch();
@@ -80,20 +77,40 @@ public class CafeDslRepositoryImpl implements CafeDslRepository {
     return cntTotal == null ? 0 : cntTotal;
   }
 
+  private JPAQuery<CafeResponseDto> baseCafeQuery() {
+    return queryFactory.select(new QCafeResponseDto(
+            cafe.id,
+            cafe.name,
+            cafe.address,
+            cafe.size,
+            review.star.avg(),
+            review.id.countDistinct(),
+            cafe.dayOff,
+            cafe.multiFamily,
+            roomCondition.existRoom(),
+            cafe.parking,
+            cafe.restaurant,
+            cafe.hyperlink,
+            cafe.openedAt,
+            cafe.closedAt))
+        .from(cafe)
+        .leftJoin(review).on(review.cafe.eq(cafe))
+        .leftJoin(room).on(room.cafe.eq(cafe));
+  }
+
   private BooleanBuilder makeWhere(SearchCondition condition) {
-    BooleanBuilder builder = new BooleanBuilder();
-    builder.and(cafeCondition.likeName(condition.getName()));
-    builder.and(cafeCondition.eqRegion(condition.getRegion()));
-    builder.and(cafeCondition.loeSize(condition.getSize()));
-    builder.and(feeCondition.ageGroup(condition));
-    builder.and(cafeCondition.parking(condition.isParking()));
-    builder.and(cafeCondition.isOpening(condition.isOpening()));
-    builder.and(cafeCondition.restaurantExists(condition.isExistRestaurant()));
-    builder.and(feeCondition.adultPrice(condition.isAdultPrice()));
-    builder.and(cafeCondition.multiFamily(condition.isMultiFamily()));
-    builder.and(cafeCondition.goeOpenedAt(condition.getOpenedAt()));
-    builder.and(cafeCondition.loeClosedAt(condition.getClosedAt()));
-    return builder;
+    return new BooleanBuilder()
+        .and(cafeCondition.likeName(condition.getName()))
+        .and(cafeCondition.eqRegion(condition.getRegion()))
+        .and(cafeCondition.loeSize(condition.getSize()))
+        .and(feeCondition.ageGroup(condition))
+        .and(cafeCondition.parking(condition.isParking()))
+        .and(cafeCondition.isOpening(condition.isOpening()))
+        .and(cafeCondition.restaurantExists(condition.isExistRestaurant()))
+        .and(feeCondition.adultPrice(condition.isAdultPrice()))
+        .and(cafeCondition.multiFamily(condition.isMultiFamily()))
+        .and(cafeCondition.goeOpenedAt(condition.getOpenedAt()))
+        .and(cafeCondition.loeClosedAt(condition.getClosedAt()));
   }
 
   private BooleanBuilder makeHaving(SearchCondition condition) {
@@ -104,13 +121,21 @@ public class CafeDslRepositoryImpl implements CafeDslRepository {
   }
 
   private OrderSpecifier<?> makeOrderBy(SearchCondition condition) {
-    boolean isAsc = condition.isAsc();
-    return switch (condition.getSortBy()) {
-      case REVIEW_COUNT -> isAsc ? review.id.count().asc() : review.id.count().desc();
-      case REVIEW_AVG -> isAsc ? review.star.avg().asc() : review.star.avg().desc();
-      case ROOM_EXIST -> isAsc ? roomCondition.existRoom().asc() :
-          roomCondition.existRoom().desc();
-      default -> new OrderSpecifier<>(Order.ASC, cafe.name);
+    Order order = condition.isAsc() ? Order.ASC : Order.DESC;
+    Expression<?> expression = makeOrderBy(condition.getSortBy());
+    if (expression instanceof ComparableExpressionBase<?> orderExpression) {
+      return new OrderSpecifier<>(order, orderExpression);
+    } else {
+      return new OrderSpecifier<>(order, cafe.name);
+    }
+  }
+
+  private Expression<?> makeOrderBy(SearchSortBy sortBy) {
+    return switch (sortBy) {
+      case REVIEW_COUNT -> review.id.count();
+      case REVIEW_AVG -> review.star.avg();
+      case ROOM_EXIST -> roomCondition.existRoom();
+      default -> cafe.name;
     };
   }
 }

--- a/src/main/java/com/sparta/kidscafe/domain/cafe/repository/CafeImageRepository.java
+++ b/src/main/java/com/sparta/kidscafe/domain/cafe/repository/CafeImageRepository.java
@@ -1,8 +1,10 @@
 package com.sparta.kidscafe.domain.cafe.repository;
 
 import com.sparta.kidscafe.domain.cafe.entity.CafeImage;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CafeImageRepository extends JpaRepository<CafeImage, Long> {
 
+  List<CafeImage> findAllByCafeId(Long cafeId);
 }

--- a/src/main/java/com/sparta/kidscafe/domain/cafe/repository/CafeRepository.java
+++ b/src/main/java/com/sparta/kidscafe/domain/cafe/repository/CafeRepository.java
@@ -4,5 +4,6 @@ import com.sparta.kidscafe.domain.cafe.entity.Cafe;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CafeRepository extends JpaRepository<Cafe, Long>, CafeDslRepository {
+
   boolean existsByIdAndUserId(Long id, Long userId);
 }

--- a/src/main/java/com/sparta/kidscafe/domain/cafe/service/CafeService.java
+++ b/src/main/java/com/sparta/kidscafe/domain/cafe/service/CafeService.java
@@ -1,5 +1,6 @@
 package com.sparta.kidscafe.domain.cafe.service;
 
+import com.sparta.kidscafe.common.dto.AuthUser;
 import com.sparta.kidscafe.common.dto.PageResponseDto;
 import com.sparta.kidscafe.common.dto.ResponseDto;
 import com.sparta.kidscafe.common.dto.StatusDto;
@@ -19,6 +20,9 @@ import com.sparta.kidscafe.domain.pricepolicy.repository.PricePolicyRepository;
 import com.sparta.kidscafe.domain.room.entity.Room;
 import com.sparta.kidscafe.domain.room.repository.RoomRepository;
 import com.sparta.kidscafe.domain.user.entity.User;
+import com.sparta.kidscafe.domain.user.repository.UserRepository;
+import com.sparta.kidscafe.exception.BusinessException;
+import com.sparta.kidscafe.exception.ErrorCode;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -36,11 +40,13 @@ public class CafeService {
   private final RoomRepository roomRepository;
   private final FeeRepository feeRepository;
   private final PricePolicyRepository pricePolicyRepository;
+  private final UserRepository userRepository;
   private final FileUtil fileUtil;
 
   @Transactional
-  public StatusDto createCafe(User user, CafeCreateRequestDto requestDto,
+  public StatusDto createCafe(AuthUser authUser, CafeCreateRequestDto requestDto,
       List<MultipartFile> cafeImages) {
+    User user = findByUserId(authUser.getId());
     Cafe cafe = saveCafe(requestDto, user);
     saveCafeImage(cafe, cafeImages);
     saveCafeDetailInfo(requestDto, cafe);
@@ -48,6 +54,11 @@ public class CafeService {
         HttpStatus.CREATED,
         "[" + cafe.getName() + "] 등록 성공"
     );
+  }
+
+  private User findByUserId(Long userId) {
+    return userRepository.findById(userId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
   }
 
   public PageResponseDto<CafeResponseDto> searchCafe(SearchCondition condition) {

--- a/src/main/java/com/sparta/kidscafe/domain/cafe/service/CafeService.java
+++ b/src/main/java/com/sparta/kidscafe/domain/cafe/service/CafeService.java
@@ -26,6 +26,7 @@ import com.sparta.kidscafe.exception.ErrorCode;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -62,15 +63,30 @@ public class CafeService {
   }
 
   public PageResponseDto<CafeResponseDto> searchCafe(SearchCondition condition) {
+    Page<CafeResponseDto> cafes = cafeRepository.searchCafe(condition);
     return PageResponseDto.success(
-        cafeRepository.searchCafe(condition),
+        cafes,
         HttpStatus.OK,
-        "카페 조회 성공"
+        cafes.isEmpty() ? "조회 결과가 없습니다." : "카페 조회 성공"
     );
   }
 
   public ResponseDto<CafeDetailResponseDto> getCafe(Long cafeId) {
     CafeResponseDto cafeResponseDto = cafeRepository.findCafeById(cafeId);
+    return ResponseDto.success(
+        getCafeDetailInfo(cafeResponseDto),
+        HttpStatus.OK,
+        cafeResponseDto == null ?
+            "조회 결과가 없습니다."
+            : "[" + cafeResponseDto.getName() + "] 상세 조회 성공"
+    );
+  }
+
+  private CafeDetailResponseDto getCafeDetailInfo(CafeResponseDto cafeResponseDto) {
+    if (cafeResponseDto == null)
+      return null;
+
+    Long cafeId = cafeResponseDto.getId();
     List<CafeImage> images = cafeImageRepository.findAllByCafeId(cafeId);
     List<Room> rooms = roomRepository.findAllByCafeId(cafeId);
     List<Fee> fees = feeRepository.findAllByCafeId(cafeId);
@@ -82,12 +98,7 @@ public class CafeService {
     cafeDetailResponseDto.setRooms(rooms);
     cafeDetailResponseDto.setFees(fees);
     cafeDetailResponseDto.setPricePolicies(pricePolicies);
-
-    return ResponseDto.success(
-        cafeDetailResponseDto,
-        HttpStatus.OK,
-        "[" + cafeDetailResponseDto.getName() + "] 상세 조회 성공"
-    );
+    return cafeDetailResponseDto;
   }
 
   private Cafe saveCafe(CafeCreateRequestDto requestDto, User user) {

--- a/src/main/java/com/sparta/kidscafe/domain/cafe/service/CafeService.java
+++ b/src/main/java/com/sparta/kidscafe/domain/cafe/service/CafeService.java
@@ -63,7 +63,7 @@ public class CafeService {
   }
 
   public PageResponseDto<CafeResponseDto> searchCafe(SearchCondition condition) {
-    Page<CafeResponseDto> cafes = cafeRepository.searchCafe(condition);
+    Page<CafeResponseDto> cafes = cafeRepository.findAllByCafe(condition);
     return PageResponseDto.success(
         cafes,
         HttpStatus.OK,
@@ -71,10 +71,10 @@ public class CafeService {
     );
   }
 
-  public ResponseDto<CafeDetailResponseDto> getCafe(Long cafeId) {
+  public ResponseDto<CafeDetailResponseDto> findCafe(Long cafeId) {
     CafeResponseDto cafeResponseDto = cafeRepository.findCafeById(cafeId);
     return ResponseDto.success(
-        getCafeDetailInfo(cafeResponseDto),
+        createCafeDetailInfo(cafeResponseDto),
         HttpStatus.OK,
         cafeResponseDto == null ?
             "조회 결과가 없습니다."
@@ -82,7 +82,7 @@ public class CafeService {
     );
   }
 
-  private CafeDetailResponseDto getCafeDetailInfo(CafeResponseDto cafeResponseDto) {
+  private CafeDetailResponseDto createCafeDetailInfo(CafeResponseDto cafeResponseDto) {
     if (cafeResponseDto == null)
       return null;
 

--- a/src/main/java/com/sparta/kidscafe/domain/cafe/service/CafeService.java
+++ b/src/main/java/com/sparta/kidscafe/domain/cafe/service/CafeService.java
@@ -1,10 +1,12 @@
 package com.sparta.kidscafe.domain.cafe.service;
 
 import com.sparta.kidscafe.common.dto.PageResponseDto;
+import com.sparta.kidscafe.common.dto.ResponseDto;
 import com.sparta.kidscafe.common.dto.StatusDto;
 import com.sparta.kidscafe.common.util.FileUtil;
 import com.sparta.kidscafe.domain.cafe.dto.SearchCondition;
 import com.sparta.kidscafe.domain.cafe.dto.request.CafeCreateRequestDto;
+import com.sparta.kidscafe.domain.cafe.dto.response.CafeDetailResponseDto;
 import com.sparta.kidscafe.domain.cafe.dto.response.CafeResponseDto;
 import com.sparta.kidscafe.domain.cafe.entity.Cafe;
 import com.sparta.kidscafe.domain.cafe.entity.CafeImage;
@@ -42,14 +44,39 @@ public class CafeService {
     Cafe cafe = saveCafe(requestDto, user);
     saveCafeImage(cafe, cafeImages);
     saveCafeDetailInfo(requestDto, cafe);
-    return createStatusDto(HttpStatus.CREATED, "[" + cafe.getName() + "] 등록 성공");
+    return createStatusDto(
+        HttpStatus.CREATED,
+        "[" + cafe.getName() + "] 등록 성공"
+    );
   }
 
   public PageResponseDto<CafeResponseDto> searchCafe(SearchCondition condition) {
     return PageResponseDto.success(
         cafeRepository.searchCafe(condition),
         HttpStatus.OK,
-        "카페 조회 성공");
+        "카페 조회 성공"
+    );
+  }
+
+  public ResponseDto<CafeDetailResponseDto> getCafe(Long cafeId) {
+    CafeResponseDto cafeResponseDto = cafeRepository.findCafeById(cafeId);
+    List<CafeImage> images = cafeImageRepository.findAllByCafeId(cafeId);
+    List<Room> rooms = roomRepository.findAllByCafeId(cafeId);
+    List<Fee> fees = feeRepository.findAllByCafeId(cafeId);
+    List<PricePolicy> pricePolicies = pricePolicyRepository.findAllByCafeId(cafeId);
+
+    CafeDetailResponseDto cafeDetailResponseDto = new CafeDetailResponseDto();
+    cafeDetailResponseDto.setCafeInfo(cafeResponseDto);
+    cafeDetailResponseDto.setCafeImage(images);
+    cafeDetailResponseDto.setRooms(rooms);
+    cafeDetailResponseDto.setFees(fees);
+    cafeDetailResponseDto.setPricePolicies(pricePolicies);
+
+    return ResponseDto.success(
+        cafeDetailResponseDto,
+        HttpStatus.OK,
+        "[" + cafeDetailResponseDto.getName() + "] 상세 조회 성공"
+    );
   }
 
   private Cafe saveCafe(CafeCreateRequestDto requestDto, User user) {

--- a/src/main/java/com/sparta/kidscafe/domain/fee/dto/response/FeeResponseDto.java
+++ b/src/main/java/com/sparta/kidscafe/domain/fee/dto/response/FeeResponseDto.java
@@ -1,5 +1,31 @@
 package com.sparta.kidscafe.domain.fee.dto.response;
 
-public class FeeResponseDto {
+import com.sparta.kidscafe.common.enums.AgeGroup;
+import com.sparta.kidscafe.domain.fee.entity.Fee;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FeeResponseDto {
+  private Long id;
+  private AgeGroup ageGroup;
+  private int fee;
+  private LocalDateTime createdAt;
+  private LocalDateTime modifiedAt;
+
+  public static FeeResponseDto from(Fee fee) {
+    return FeeResponseDto.builder()
+        .id(fee.getId())
+        .ageGroup(fee.getAgeGroup())
+        .fee(fee.getFee())
+        .createdAt(fee.getCreatedAt())
+        .modifiedAt(fee.getModifiedAt())
+        .build();
+  }
 }

--- a/src/main/java/com/sparta/kidscafe/domain/fee/repository/FeeRepository.java
+++ b/src/main/java/com/sparta/kidscafe/domain/fee/repository/FeeRepository.java
@@ -1,8 +1,10 @@
 package com.sparta.kidscafe.domain.fee.repository;
 
 import com.sparta.kidscafe.domain.fee.entity.Fee;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FeeRepository extends JpaRepository<Fee, Long> {
 
+  List<Fee> findAllByCafeId(Long cafeId);
 }

--- a/src/main/java/com/sparta/kidscafe/domain/pricepolicy/dto/response/PricePolicyResponseDto.java
+++ b/src/main/java/com/sparta/kidscafe/domain/pricepolicy/dto/response/PricePolicyResponseDto.java
@@ -2,31 +2,39 @@ package com.sparta.kidscafe.domain.pricepolicy.dto.response;
 
 import com.sparta.kidscafe.common.enums.TargetType;
 import com.sparta.kidscafe.domain.pricepolicy.entity.PricePolicy;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-@Getter
 @Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class PricePolicyResponseDto {
-    private Long id;           // 정책 ID
-    private String title;      // 정책 제목
-    private Long cafeId;       // 카페 ID
-    private TargetType targetType; // 정책 대상 종류
-    private Long targetId;     // 대상 ID
-    private String targetName; // 대상 이름
-    private String dayType;    // 적용 요일
-    private Double rate;       // 요금 비율
 
-    public static PricePolicyResponseDto fromEntity(PricePolicy policy, String targetName) {
-        return PricePolicyResponseDto.builder()
-                .id(policy.getId())
-                .title(policy.getTitle())
-                .cafeId(policy.getCafe().getId())
-                .targetType(policy.getTargetType())
-                .targetId(policy.getTargetId())
-                .targetName(targetName)
-                .dayType(policy.getDayType())
-                .rate(policy.getRate())
-                .build();
-    }
+  private Long id;                // 정책 ID
+  private Long cafeId;            // 카페 ID
+  private TargetType targetType;  // 정책 대상 종류
+  private Long targetId;          // 대상 ID
+  private String title;           // 정책 제목
+  private String workDay;         // 적용 요일
+  private Double rate;            // 요금 비율
+  private LocalDateTime createdAt;
+  private LocalDateTime modifiedAt;
+
+  public static PricePolicyResponseDto from(PricePolicy pricePolicy) {
+    return PricePolicyResponseDto.builder()
+        .id(pricePolicy.getId())
+        .cafeId(pricePolicy.getCafe().getId())
+        .targetType(pricePolicy.getTargetType())
+        .targetId(pricePolicy.getTargetId())
+        .title(pricePolicy.getTitle())
+        .rate(pricePolicy.getRate())
+        .workDay(pricePolicy.getDayType())
+        .createdAt(pricePolicy.getCreatedAt())
+        .modifiedAt(pricePolicy.getModifiedAt())
+        .build();
+  }
 }

--- a/src/main/java/com/sparta/kidscafe/domain/pricepolicy/repository/PricePolicyRepository.java
+++ b/src/main/java/com/sparta/kidscafe/domain/pricepolicy/repository/PricePolicyRepository.java
@@ -1,15 +1,14 @@
 package com.sparta.kidscafe.domain.pricepolicy.repository;
 
 import com.sparta.kidscafe.domain.pricepolicy.entity.PricePolicy;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PricePolicyRepository extends JpaRepository<PricePolicy, Long> {
 
-    List<PricePolicy> findAllByCafeId(Long cafeId);
+  List<PricePolicy> findAllByCafeId(Long cafeId);
 
-    List<PricePolicy> findAllByCafeIdAndTargetId(Long cafeId, Long targetId);
+  List<PricePolicy> findAllByCafeIdAndTargetId(Long cafeId, Long targetId);
 
-    boolean existsByCafeId(Long cafeId);
+  boolean existsByCafeId(Long cafeId);
 }

--- a/src/main/java/com/sparta/kidscafe/domain/pricepolicy/service/PricePolicyService.java
+++ b/src/main/java/com/sparta/kidscafe/domain/pricepolicy/service/PricePolicyService.java
@@ -53,7 +53,7 @@ public class PricePolicyService {
 
         // 정책 조회 및 변환
         return pricePolicyRepository.findAllByCafeId(cafeId).stream()
-                .map(policy -> PricePolicyResponseDto.fromEntity(policy, policy.getTargetName()))
+                .map(PricePolicyResponseDto::from)
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/sparta/kidscafe/domain/room/dto/response/RoomResponseDto.java
+++ b/src/main/java/com/sparta/kidscafe/domain/room/dto/response/RoomResponseDto.java
@@ -1,5 +1,36 @@
 package com.sparta.kidscafe.domain.room.dto.response;
 
-public class RoomResponseDto {
+import com.sparta.kidscafe.domain.room.entity.Room;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class RoomResponseDto {
+  private Long id;
+  private String name;
+  private String description;
+  private int minCount;
+  private int maxCount;
+  private int price;
+  private LocalDateTime createdAt;
+  private LocalDateTime modifiedAt;
+
+  public static RoomResponseDto from(Room room) {
+    return RoomResponseDto.builder()
+        .id(room.getId())
+        .name(room.getName())
+        .description(room.getDescription())
+        .minCount(room.getMinCount())
+        .maxCount(room.getMaxCount())
+        .price(room.getPrice())
+        .createdAt(room.getCreatedAt())
+        .modifiedAt(room.getModifiedAt())
+        .build();
+  }
 }

--- a/src/main/java/com/sparta/kidscafe/domain/room/repository/RoomRepository.java
+++ b/src/main/java/com/sparta/kidscafe/domain/room/repository/RoomRepository.java
@@ -1,8 +1,10 @@
 package com.sparta.kidscafe.domain.room.repository;
 
 import com.sparta.kidscafe.domain.room.entity.Room;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RoomRepository extends JpaRepository<Room, Long> {
 
+  List<Room> findAllByCafeId(Long cafeId);
 }

--- a/src/test/java/com/sparta/kidscafe/domain/cafe/service/CafeServiceTest.java
+++ b/src/test/java/com/sparta/kidscafe/domain/cafe/service/CafeServiceTest.java
@@ -10,13 +10,16 @@ import static org.mockito.Mockito.when;
 
 import com.sparta.kidscafe.common.dto.AuthUser;
 import com.sparta.kidscafe.common.dto.PageResponseDto;
+import com.sparta.kidscafe.common.dto.ResponseDto;
 import com.sparta.kidscafe.common.dto.StatusDto;
 import com.sparta.kidscafe.common.enums.RoleType;
 import com.sparta.kidscafe.common.util.FileUtil;
 import com.sparta.kidscafe.domain.cafe.dto.SearchCondition;
 import com.sparta.kidscafe.domain.cafe.dto.request.CafeCreateRequestDto;
+import com.sparta.kidscafe.domain.cafe.dto.response.CafeDetailResponseDto;
 import com.sparta.kidscafe.domain.cafe.dto.response.CafeResponseDto;
 import com.sparta.kidscafe.domain.cafe.entity.Cafe;
+import com.sparta.kidscafe.domain.cafe.entity.CafeImage;
 import com.sparta.kidscafe.domain.cafe.repository.CafeImageRepository;
 import com.sparta.kidscafe.domain.cafe.repository.CafeRepository;
 import com.sparta.kidscafe.domain.fee.entity.Fee;
@@ -189,5 +192,77 @@ public class CafeServiceTest {
     assertThat(response.getData()).hasSize(2); // 반환된 데이터 크기 확인
     assertThat(response.getData().get(0).getName()).isEqualTo("Test Cafe"); // 첫 번째 Cafe 이름 확인
     assertThat(response.getData().get(1).getName()).isEqualTo("Another Cafe"); // 두 번째 Cafe 이름 확인
+  }
+
+  @Test
+  @DisplayName("카페 상세 조회 성공")
+  void getCafe_success() {
+    // given
+    Long cafeId = 1L;
+    CafeResponseDto cafeResponseDto = new CafeResponseDto(
+        1L,
+        "Test Cafe",
+        "Seoul",
+        50,
+        4.5,
+        20L,
+        "월",
+        true,
+        true,
+        true,
+        true,
+        "http://..",
+        null,
+        null);
+    List<CafeImage> images = Collections.emptyList();
+    List<Room> rooms = Collections.emptyList();
+    List<Fee> fees = Collections.emptyList();
+    List<PricePolicy> pricePolicies = Collections.emptyList();
+
+    when(cafeRepository.findCafeById(cafeId)).thenReturn(cafeResponseDto);
+    when(cafeImageRepository.findAllByCafeId(cafeId)).thenReturn(images);
+    when(roomRepository.findAllByCafeId(cafeId)).thenReturn(rooms);
+    when(feeRepository.findAllByCafeId(cafeId)).thenReturn(fees);
+    when(pricePolicyRepository.findAllByCafeId(cafeId)).thenReturn(pricePolicies);
+
+    // when
+    CafeService service = new CafeService(
+        cafeRepository,
+        cafeImageRepository,
+        roomRepository,
+        feeRepository,
+        pricePolicyRepository,
+        userRepository,
+        fileUtil);
+    ResponseDto<CafeDetailResponseDto> response = service.getCafe(cafeId);
+
+    // then
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+    assertThat(response.getData()).isNotNull();
+    assertThat(response.getMessage()).isEqualTo("[Test Cafe] 상세 조회 성공");
+  }
+
+  @Test
+  @DisplayName("카페 상세 조회 - 조회 결과가 없음")
+  void getCafe_notFound() {
+    // given
+    Long cafeId = 1L;
+    when(cafeRepository.findCafeById(cafeId)).thenReturn(null);
+
+    // when
+    CafeService service = new CafeService(
+        cafeRepository,
+        cafeImageRepository,
+        roomRepository,
+        feeRepository,
+        pricePolicyRepository,
+        userRepository,
+        fileUtil);
+    ResponseDto<CafeDetailResponseDto> response = service.getCafe(cafeId);
+
+    // then
+    assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+    assertThat(response.getData()).isNull();
+    assertThat(response.getMessage()).isEqualTo("조회 결과가 없습니다.");
   }
 }

--- a/src/test/java/com/sparta/kidscafe/domain/cafe/service/CafeServiceTest.java
+++ b/src/test/java/com/sparta/kidscafe/domain/cafe/service/CafeServiceTest.java
@@ -121,8 +121,35 @@ public class CafeServiceTest {
         .build();
 
     List<CafeResponseDto> cafeResponseDtoList = Arrays.asList(
-        new CafeResponseDto(1L, "Test Cafe", "Seoul", 50, 4.5, 20L, true, true, true, null, null),
-        new CafeResponseDto(2L, "Another Cafe", "Seoul", 30, 4.0, 15L, true, true, false, null,
+        new CafeResponseDto(
+            1L,
+            "Test Cafe",
+            "Seoul",
+            50,
+            4.5,
+            20L,
+            "월",
+            true,
+            true,
+            true,
+            true,
+            "http://..",
+            null,
+            null),
+        new CafeResponseDto(
+            2L,
+            "Another Cafe",
+            "Seoul",
+            30,
+            4.0,
+            15L,
+            "토, 일",
+            true,
+            true,
+            false,
+            true,
+            "http://..",
+            null,
             null)
     );
 

--- a/src/test/java/com/sparta/kidscafe/domain/cafe/service/CafeServiceTest.java
+++ b/src/test/java/com/sparta/kidscafe/domain/cafe/service/CafeServiceTest.java
@@ -175,7 +175,7 @@ public class CafeServiceTest {
         searchCondition.getPageable(), 2);
 
     // Mock 동작 설정: Repository 호출 시 Mock 결과 반환
-    when(cafeRepository.searchCafe(any(SearchCondition.class))).thenReturn(mockPage);
+    when(cafeRepository.findAllByCafe(any(SearchCondition.class))).thenReturn(mockPage);
 
     // Act: 테스트 대상 메서드 호출
     CafeService service = new CafeService(
@@ -196,7 +196,7 @@ public class CafeServiceTest {
 
   @Test
   @DisplayName("카페 상세 조회 성공")
-  void getCafe_success() {
+  void findCafe_success() {
     // given
     Long cafeId = 1L;
     CafeResponseDto cafeResponseDto = new CafeResponseDto(
@@ -234,7 +234,7 @@ public class CafeServiceTest {
         pricePolicyRepository,
         userRepository,
         fileUtil);
-    ResponseDto<CafeDetailResponseDto> response = service.getCafe(cafeId);
+    ResponseDto<CafeDetailResponseDto> response = service.findCafe(cafeId);
 
     // then
     assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
@@ -244,7 +244,7 @@ public class CafeServiceTest {
 
   @Test
   @DisplayName("카페 상세 조회 - 조회 결과가 없음")
-  void getCafe_notFound() {
+  void findCafe_notFound() {
     // given
     Long cafeId = 1L;
     when(cafeRepository.findCafeById(cafeId)).thenReturn(null);
@@ -258,7 +258,7 @@ public class CafeServiceTest {
         pricePolicyRepository,
         userRepository,
         fileUtil);
-    ResponseDto<CafeDetailResponseDto> response = service.getCafe(cafeId);
+    ResponseDto<CafeDetailResponseDto> response = service.findCafe(cafeId);
 
     // then
     assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());

--- a/src/test/java/com/sparta/kidscafe/domain/fee/repository/FeeRepository.java
+++ b/src/test/java/com/sparta/kidscafe/domain/fee/repository/FeeRepository.java
@@ -1,8 +1,9 @@
 package com.sparta.kidscafe.domain.fee.repository;
 
 import com.sparta.kidscafe.domain.fee.entity.Fee;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FeeRepository extends JpaRepository<Fee, Long> {
-
+  List<Fee> findAllByCafeId(Long cafeId);
 }


### PR DESCRIPTION
## 🔘 담당 파트
- 카페 상세 조회

## 🔎 작업 상세 내용
- 카페에 대한 정보를 상세 조회한다.

## 🔧 앞으로의 과제
-  카페 등록(admin)
- 카페 리스트 조회(관리자 검색한)
- 카페 리스트 조회(사장님이 등록한)
- 카페 수정
- 카페 삭제(ADMIN)
- 카페 삭제(OWNER)
- 카페 검색 시 지역 이름을 가져오도록 보완 필요
- 로그인 적용 필요

## ➕ 이슈 링크
- #70