### PR TITLE
feat: 카페 등록(관리자) 구현

### DIFF
--- a/src/main/java/com/sparta/kidscafe/common/util/FileUtil.java
+++ b/src/main/java/com/sparta/kidscafe/common/util/FileUtil.java
@@ -30,7 +30,7 @@ public class FileUtil {
 
   public String makeFileName(String dirPath, Long id, MultipartFile image) {
     StringBuilder imagePath = new StringBuilder(dirPath);
-    imagePath.append("cafeImage");
+    imagePath.append("image");
     imagePath.append("_");
     imagePath.append(id);
     imagePath.append("_");
@@ -43,7 +43,7 @@ public class FileUtil {
       image.transferTo(new File(uploadPath));
     } catch (IOException ex) {
       ex.printStackTrace();
-      throw new BusinessException(ErrorCode.CAFE_IMAGE_UPLOAD_FAILED);
+      throw new BusinessException(ErrorCode.IMAGE_UPLOAD_FAILED);
     }
   }
 

--- a/src/main/java/com/sparta/kidscafe/domain/cafe/controller/CafeController.java
+++ b/src/main/java/com/sparta/kidscafe/domain/cafe/controller/CafeController.java
@@ -8,6 +8,7 @@ import com.sparta.kidscafe.common.dto.StatusDto;
 import com.sparta.kidscafe.domain.cafe.dto.request.CafeCreateRequestDto;
 import com.sparta.kidscafe.domain.cafe.dto.request.CafeModifyRequestDto;
 import com.sparta.kidscafe.domain.cafe.dto.request.CafeSearchRequestDto;
+import com.sparta.kidscafe.domain.cafe.dto.request.CafesSimpleCreateRequestDto;
 import com.sparta.kidscafe.domain.cafe.dto.response.CafeDetailResponseDto;
 import com.sparta.kidscafe.domain.cafe.dto.response.CafeResponseDto;
 import com.sparta.kidscafe.domain.cafe.service.CafeService;
@@ -42,6 +43,16 @@ public class CafeController {
     return ResponseEntity
         .status(HttpStatus.CREATED)
         .body(cafeService.createCafe(authUser, requestDto, cafeImages));
+  }
+
+  @PostMapping("/admin/cafes")
+  public ResponseEntity<StatusDto> createCafe(
+      @Auth AuthUser authUser,
+      @Valid @RequestBody CafesSimpleCreateRequestDto requestDto
+  ) {
+    return ResponseEntity
+        .status(HttpStatus.CREATED)
+        .body(cafeService.creatCafe(authUser, requestDto));
   }
 
   @GetMapping("/cafes")

--- a/src/main/java/com/sparta/kidscafe/domain/cafe/dto/request/CafeSimpleCreateRequestDto.java
+++ b/src/main/java/com/sparta/kidscafe/domain/cafe/dto/request/CafeSimpleCreateRequestDto.java
@@ -1,0 +1,58 @@
+package com.sparta.kidscafe.domain.cafe.dto.request;
+
+import com.sparta.kidscafe.domain.cafe.entity.Cafe;
+import com.sparta.kidscafe.domain.user.entity.User;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Positive;
+import java.time.LocalTime;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CafeSimpleCreateRequestDto {
+  @NotBlank(message = "카페 이름을 입력해주세요.")
+  private String name;
+
+  @NotBlank(message = "지역명은 빈칸으로 둘 수 없습니다.")
+  private String region;
+
+  @NotBlank(message = "주소를 입력해 주세요.")
+  private String address;
+
+  @Positive(message = "카페 크기는 0이상입니다.")
+  private int size;
+
+  private boolean multiFamily;
+
+  @Pattern(
+      regexp = "^(월|화|수|목|금|토|일)(,\\s*(월|화|수|목|금|토|일))*$",
+      message = "DayType은 요일을 쉼표로 구분하여 입력해야 합니다. (예: '월, 화, 수')"
+  )
+  private String dayOff;
+  private boolean parking;
+  private boolean restaurant;
+  private String hyperLink;
+  private LocalTime openedAt;
+  private LocalTime closedAt;
+
+  public Cafe convertDtoToEntityByCafe(User user) {
+    return Cafe.builder()
+        .user(user)
+        .name(name)
+        .region(region)
+        .address(address)
+        .size(size)
+        .multiFamily(multiFamily)
+        .dayOff(dayOff)
+        .parking(parking)
+        .restaurant(restaurant)
+        .hyperlink(hyperLink)
+        .openedAt(openedAt)
+        .closedAt(closedAt)
+        .build();
+  }
+}

--- a/src/main/java/com/sparta/kidscafe/domain/cafe/dto/request/CafesSimpleCreateRequestDto.java
+++ b/src/main/java/com/sparta/kidscafe/domain/cafe/dto/request/CafesSimpleCreateRequestDto.java
@@ -1,0 +1,28 @@
+package com.sparta.kidscafe.domain.cafe.dto.request;
+
+import com.sparta.kidscafe.domain.cafe.entity.Cafe;
+import com.sparta.kidscafe.domain.user.entity.User;
+import jakarta.validation.Valid;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CafesSimpleCreateRequestDto {
+
+  @Valid
+  private List<CafeSimpleCreateRequestDto> cafes;
+
+  public List<Cafe> convertDtoToEntity(User user) {
+    List<Cafe> cafes = new ArrayList<>();
+    for (CafeSimpleCreateRequestDto cafeDto : this.cafes) {
+      Cafe cafe = cafeDto.convertDtoToEntityByCafe(user);
+      cafes.add(cafe);
+    }
+    return cafes;
+  }
+}

--- a/src/main/java/com/sparta/kidscafe/domain/cafe/service/CafeService.java
+++ b/src/main/java/com/sparta/kidscafe/domain/cafe/service/CafeService.java
@@ -7,6 +7,7 @@ import com.sparta.kidscafe.common.dto.StatusDto;
 import com.sparta.kidscafe.domain.cafe.dto.SearchCondition;
 import com.sparta.kidscafe.domain.cafe.dto.request.CafeCreateRequestDto;
 import com.sparta.kidscafe.domain.cafe.dto.request.CafeModifyRequestDto;
+import com.sparta.kidscafe.domain.cafe.dto.request.CafesSimpleCreateRequestDto;
 import com.sparta.kidscafe.domain.cafe.dto.response.CafeDetailResponseDto;
 import com.sparta.kidscafe.domain.cafe.dto.response.CafeResponseDto;
 import com.sparta.kidscafe.domain.cafe.entity.Cafe;
@@ -51,6 +52,17 @@ public class CafeService {
     return createStatusDto(
         HttpStatus.CREATED,
         "[" + cafe.getName() + "] 등록 성공"
+    );
+  }
+
+  public StatusDto creatCafe(AuthUser authUser, CafesSimpleCreateRequestDto requestDto) {
+    CafeValidationCheck.validCreateCafeByAdmin(authUser);
+    User user = findByUserId(authUser.getId());
+    List<Cafe> cafes = requestDto.convertDtoToEntity(user);
+    cafeRepository.saveAll(cafes);
+    return createStatusDto(
+        HttpStatus.CREATED,
+        "카페 ["+ cafes.size() +"]개 등록 성공"
     );
   }
 

--- a/src/main/java/com/sparta/kidscafe/domain/cafe/service/CafeValidationCheck.java
+++ b/src/main/java/com/sparta/kidscafe/domain/cafe/service/CafeValidationCheck.java
@@ -1,0 +1,18 @@
+package com.sparta.kidscafe.domain.cafe.service;
+
+import com.sparta.kidscafe.common.dto.AuthUser;
+import com.sparta.kidscafe.common.enums.RoleType;
+import com.sparta.kidscafe.exception.BusinessException;
+import com.sparta.kidscafe.exception.ErrorCode;
+
+public class CafeValidationCheck {
+
+  public static void validAdmin(AuthUser authUser) {
+    if(authUser.getRoleType() != RoleType.ADMIN)
+      throw new BusinessException(ErrorCode.FORBIDDEN);
+  }
+
+  public static void validCreateCafeByAdmin(AuthUser authUser) {
+    validAdmin(authUser);
+  }
+}

--- a/src/main/java/com/sparta/kidscafe/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/kidscafe/exception/ErrorCode.java
@@ -13,9 +13,11 @@ public enum ErrorCode {
     // Cafe 관련 에러
     CAFE_NOT_FOUND("CAFE_NOT_FOUND", "카페를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     INVALID_CAFE_DATA("INVALID_CAFE_DATA", "카페 데이터가 유효하지 않습니다.", HttpStatus.BAD_REQUEST),
-    CAFE_IMAGE_UPLOAD_FAILED("CAFE_IMAGE_UPLOAD_FAILED", "카페 이미지 업로드에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-    IMAGE_REMOVE_FAILED("CAFE_IMAGE_UPLOAD_FAILED", "카페 이미지 삭제에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
-    IMAGE_NOT_EXIST("", "카페 이미지가 존재하지 않습니다.",HttpStatus.INTERNAL_SERVER_ERROR),
+
+    // Image 관련 에러
+    IMAGE_UPLOAD_FAILED("IMAGE_UPLOAD_FAILED", "카페 이미지 업로드에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    IMAGE_REMOVE_FAILED("IMAGE_REMOVE_FAILED", "카페 이미지 삭제에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    IMAGE_NOT_EXIST("IMAGE_NOT_EXIST", "이미지가 존재하지 않습니다.",HttpStatus.INTERNAL_SERVER_ERROR),
 
     // Review 관련 에러
     REVIEW_NOT_FOUND("REVIEW_NOT_FOUND", "리뷰를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),

--- a/src/test/java/com/sparta/kidscafe/domain/cafe/service/CafeServiceTest.java
+++ b/src/test/java/com/sparta/kidscafe/domain/cafe/service/CafeServiceTest.java
@@ -1,9 +1,11 @@
 package com.sparta.kidscafe.domain.cafe.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.anyList;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -15,6 +17,7 @@ import com.sparta.kidscafe.common.dto.StatusDto;
 import com.sparta.kidscafe.common.enums.RoleType;
 import com.sparta.kidscafe.domain.cafe.dto.SearchCondition;
 import com.sparta.kidscafe.domain.cafe.dto.request.CafeCreateRequestDto;
+import com.sparta.kidscafe.domain.cafe.dto.request.CafesSimpleCreateRequestDto;
 import com.sparta.kidscafe.domain.cafe.dto.response.CafeDetailResponseDto;
 import com.sparta.kidscafe.domain.cafe.dto.response.CafeResponseDto;
 import com.sparta.kidscafe.domain.cafe.entity.Cafe;
@@ -28,6 +31,8 @@ import com.sparta.kidscafe.domain.room.entity.Room;
 import com.sparta.kidscafe.domain.room.repository.RoomRepository;
 import com.sparta.kidscafe.domain.user.entity.User;
 import com.sparta.kidscafe.domain.user.repository.UserRepository;
+import com.sparta.kidscafe.exception.BusinessException;
+import com.sparta.kidscafe.exception.ErrorCode;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -65,16 +70,30 @@ public class CafeServiceTest {
   @Mock
   private CafeImageService cafeImageService;
 
+  private CafeService cafeService;
   private AuthUser authUser;
+  private AuthUser adminAuthUser;
   private User user;
+  private User adminUser;
   private CafeCreateRequestDto requestDto;
   private List<MultipartFile> cafeImages;
 
   @BeforeEach
   void setUp() {
-    // 테스트를 위한 기본 User 및 Request DTO 생성
+    cafeService = new CafeService(
+        cafeRepository,
+        roomRepository,
+        feeRepository,
+        pricePolicyRepository,
+        userRepository,
+        cafeImageService);
+
     authUser = new AuthUser(15L, "test@email.com", RoleType.OWNER);
+    adminAuthUser = new AuthUser(15L, "test@email.com", RoleType.ADMIN);
+
     user = User.builder().id(authUser.getId()).build();
+    adminUser = User.builder().id(adminAuthUser.getId()).role(RoleType.ADMIN).build();
+
     requestDto = mock(CafeCreateRequestDto.class);
     cafeImages = Arrays.asList(mock(MultipartFile.class), mock(MultipartFile.class));
   }
@@ -95,20 +114,11 @@ public class CafeServiceTest {
     when(cafe.getName())
         .thenReturn("Test Cafe");
 
-    // when: createCafe 메서드 호출
-    CafeService service = new CafeService(
-        cafeRepository,
-        roomRepository,
-        feeRepository,
-        pricePolicyRepository,
-        userRepository,
-        cafeImageService);
-
     // Mock 동작 설정: Repository 호출 시 Mock 결과 반환
     when(userRepository.findById(authUser.getId())).thenReturn(Optional.of(user));
 
     // when: 실행
-    StatusDto result = service.createCafe(authUser, requestDto, cafeImages);
+    StatusDto result = cafeService.createCafe(authUser, requestDto, cafeImages);
 
     // then: 결과 확인
     assert (result.getStatus() == HttpStatus.CREATED.value());
@@ -172,14 +182,7 @@ public class CafeServiceTest {
     when(cafeRepository.findAllByCafe(any(SearchCondition.class))).thenReturn(mockPage);
 
     // Act: 테스트 대상 메서드 호출
-    CafeService service = new CafeService(
-        cafeRepository,
-        roomRepository,
-        feeRepository,
-        pricePolicyRepository,
-        userRepository,
-        cafeImageService);
-    PageResponseDto<CafeResponseDto> response = service.searchCafe(searchCondition);
+    PageResponseDto<CafeResponseDto> response = cafeService.searchCafe(searchCondition);
 
     // Assert: 반환값 검증
     assertThat(response.getData()).hasSize(2); // 반환된 데이터 크기 확인
@@ -219,14 +222,7 @@ public class CafeServiceTest {
     when(pricePolicyRepository.findAllByCafeId(cafeId)).thenReturn(pricePolicies);
 
     // when
-    CafeService service = new CafeService(
-        cafeRepository,
-        roomRepository,
-        feeRepository,
-        pricePolicyRepository,
-        userRepository,
-        cafeImageService);
-    ResponseDto<CafeDetailResponseDto> response = service.findCafe(cafeId);
+    ResponseDto<CafeDetailResponseDto> response = cafeService.findCafe(cafeId);
 
     // then
     assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
@@ -242,18 +238,67 @@ public class CafeServiceTest {
     when(cafeRepository.findCafeById(cafeId)).thenReturn(null);
 
     // when
-    CafeService service = new CafeService(
-        cafeRepository,
-        roomRepository,
-        feeRepository,
-        pricePolicyRepository,
-        userRepository,
-        cafeImageService);
-    ResponseDto<CafeDetailResponseDto> response = service.findCafe(cafeId);
+    ResponseDto<CafeDetailResponseDto> response = cafeService.findCafe(cafeId);
 
     // then
     assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
     assertThat(response.getData()).isNull();
     assertThat(response.getMessage()).isEqualTo("조회 결과가 없습니다.");
+  }
+
+  @Test
+  @DisplayName("관리자 카페 등록 성공")
+  void createCafe_admin_success() {
+    // given: Mock 데이터와 의존성 설정
+    Cafe cafe1 = mock(Cafe.class);
+    Cafe cafe2 = mock(Cafe.class);
+    List<Cafe> cafes = Arrays.asList(cafe1, cafe2);
+
+    CafesSimpleCreateRequestDto requestDto = mock(CafesSimpleCreateRequestDto.class);
+    when(userRepository.findById(adminUser.getId())).thenReturn(Optional.of(adminUser));
+    when(requestDto.convertDtoToEntity(adminUser)).thenReturn(cafes);
+
+    // when: 서비스 호출
+    StatusDto result = cafeService.creatCafe(adminAuthUser, requestDto);
+
+    // then: 결과 검증
+    assertThat(result.getStatus()).isEqualTo(HttpStatus.CREATED.value());
+    assertThat(result.getMessage()).isEqualTo("카페 [" + cafes.size() + "]개 등록 성공");
+
+    // verify: 레포지토리 호출 검증
+    verify(cafeRepository, times(1)).saveAll(cafes);
+  }
+
+  @Test
+  @DisplayName("관리자 카페 등록 실패 - 유저를 찾을 수 없음")
+  void createCafe_admin_userNotFound() {
+    // given: Mock 데이터 설정
+    CafesSimpleCreateRequestDto requestDto = mock(CafesSimpleCreateRequestDto.class);
+    when(userRepository.findById(adminUser.getId())).thenReturn(Optional.empty());
+
+    // when & then: 예외 검증
+    BusinessException exception = assertThrows(BusinessException.class, () ->
+        cafeService.creatCafe(adminAuthUser, requestDto)
+    );
+    assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.USER_NOT_FOUND);
+
+    // verify: 레포지토리가 호출되지 않았는지 검증
+    verify(cafeRepository, never()).saveAll(anyList());
+  }
+
+  @Test
+  @DisplayName("관리자 카페 등록 실패 - 관리자 권한 없음")
+  void createCafe_admin_forbidden() {
+    // given: Mock 데이터 설정
+    CafesSimpleCreateRequestDto requestDto = mock(CafesSimpleCreateRequestDto.class);
+
+    // when & then: 예외 검증
+    BusinessException exception = assertThrows(BusinessException.class, () ->
+        cafeService.creatCafe(authUser, requestDto)
+    );
+    assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.FORBIDDEN);
+
+    // verify: 레포지토리가 호출되지 않았는지 검증
+    verify(cafeRepository, never()).saveAll(anyList());
   }
 }


### PR DESCRIPTION
## 🔘 담당 파트
- 카페 등록(ADMIN)

## 🔎 작업 상세 내용
- 관리자 카페 등록 기능 구현
- 관리자는 여러개의 카페를 한번에 등록할 수 있다. (초기 크롤링 컨셉을 반영)
- 테스트 코드 작성

## 🔧 앞으로의 과제
- 카페 리스트 조회(관리자 검색한)
- 카페 리스트 조회(사장님이 등록한)
- 카페 삭제(ADMIN)
- 카페 삭제(OWNER)
- 카페 검색 지역 검색쪽 보완 필요
- S3로 대체 필요

## ➕ 이슈 링크
- #95