### PR TITLE
예약 생성 기능

### DIFF
--- a/src/main/java/com/sparta/kidscafe/common/enums/TargetType.java
+++ b/src/main/java/com/sparta/kidscafe/common/enums/TargetType.java
@@ -20,7 +20,8 @@ public enum TargetType {
                 return targetType;
             }
         }
-        return FEE; // 기본값 설정
+        return ROOM; // 기본값 설정
+
     }
 
     @JsonValue

--- a/src/main/java/com/sparta/kidscafe/domain/pricepolicy/repository/PricePolicyRepository.java
+++ b/src/main/java/com/sparta/kidscafe/domain/pricepolicy/repository/PricePolicyRepository.java
@@ -11,4 +11,6 @@ public interface PricePolicyRepository extends JpaRepository<PricePolicy, Long> 
   List<PricePolicy> findAllByCafeIdAndTargetId(Long cafeId, Long targetId);
 
   boolean existsByCafeId(Long cafeId);
+
+  List<PricePolicy> findByCafeIdAndDayTypeContains(Long cafeId, String dayType);
 }

--- a/src/main/java/com/sparta/kidscafe/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/com/sparta/kidscafe/domain/reservation/controller/ReservationController.java
@@ -1,10 +1,36 @@
 package com.sparta.kidscafe.domain.reservation.controller;
 
+import com.sparta.kidscafe.common.annotation.Auth;
+import com.sparta.kidscafe.common.dto.AuthUser;
+import com.sparta.kidscafe.common.dto.StatusDto;
+import com.sparta.kidscafe.domain.reservation.dto.request.ReservationCreateRequestDto;
+import com.sparta.kidscafe.domain.reservation.service.ReservationService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api")
 public class ReservationController {
+
+  private final ReservationService reservationService;
+
+  @PostMapping("/reservations/cafes/{cafeId}")
+  public ResponseEntity<StatusDto> createReservation(
+      @Auth AuthUser authUser,
+      @PathVariable Long cafeId,
+      @Valid @RequestBody ReservationCreateRequestDto requestDto) {
+    StatusDto response = reservationService.createReservation(authUser, cafeId, requestDto);
+    return ResponseEntity.status(HttpStatus.CREATED).body(response);
+  }
+
+
 
 }

--- a/src/main/java/com/sparta/kidscafe/domain/reservation/dto/request/ReservationCreateRequestDto.java
+++ b/src/main/java/com/sparta/kidscafe/domain/reservation/dto/request/ReservationCreateRequestDto.java
@@ -1,4 +1,30 @@
 package com.sparta.kidscafe.domain.reservation.dto.request;
 
+import com.sparta.kidscafe.common.enums.TargetType;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Data
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class ReservationCreateRequestDto {
+
+  private LocalDateTime startedAt;
+  private LocalDateTime finishedAt;
+  private List<ReservationDetailRequestDto> details;
+
+  @Getter
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class ReservationDetailRequestDto {
+
+    private TargetType targetType;
+    private Long targetId;
+    private int count;
+  }
 }

--- a/src/main/java/com/sparta/kidscafe/domain/reservation/dto/request/ReservationDetailCreateRequestDto.java
+++ b/src/main/java/com/sparta/kidscafe/domain/reservation/dto/request/ReservationDetailCreateRequestDto.java
@@ -1,5 +1,0 @@
-package com.sparta.kidscafe.domain.reservation.dto.request;
-
-public class ReservationDetailCreateRequestDto {
-
-}

--- a/src/main/java/com/sparta/kidscafe/domain/reservation/dto/response/ReservationDetailResponseDto.java
+++ b/src/main/java/com/sparta/kidscafe/domain/reservation/dto/response/ReservationDetailResponseDto.java
@@ -1,5 +1,0 @@
-package com.sparta.kidscafe.domain.reservation.dto.response;
-
-public class ReservationDetailResponseDto {
-
-}

--- a/src/main/java/com/sparta/kidscafe/domain/reservation/dto/response/ReservationResponseDto.java
+++ b/src/main/java/com/sparta/kidscafe/domain/reservation/dto/response/ReservationResponseDto.java
@@ -1,4 +1,37 @@
 package com.sparta.kidscafe.domain.reservation.dto.response;
 
+import com.sparta.kidscafe.common.enums.TargetType;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class ReservationResponseDto {
+
+  private Long reservationId;
+  private String cafeName;
+  private String roomName;
+  private LocalDateTime startedAt;
+  private LocalDateTime finishedAt;
+  private int totalPrice;
+  private String status;
+  private List<ReservationDetailResponseDto> details;
+
+  @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
+  public static class ReservationDetailResponseDto {
+    private TargetType targetType;
+    private String targetName;
+    private int price;
+    private Long count;
+  }
 }

--- a/src/main/java/com/sparta/kidscafe/domain/reservation/service/ReservationCalculationService.java
+++ b/src/main/java/com/sparta/kidscafe/domain/reservation/service/ReservationCalculationService.java
@@ -1,0 +1,57 @@
+package com.sparta.kidscafe.domain.reservation.service;
+
+import com.sparta.kidscafe.common.enums.TargetType;
+import com.sparta.kidscafe.domain.cafe.entity.Cafe;
+import com.sparta.kidscafe.domain.fee.entity.Fee;
+import com.sparta.kidscafe.domain.fee.repository.FeeRepository;
+import com.sparta.kidscafe.domain.pricepolicy.entity.PricePolicy;
+import com.sparta.kidscafe.domain.pricepolicy.repository.PricePolicyRepository;
+import com.sparta.kidscafe.domain.reservation.dto.request.ReservationCreateRequestDto;
+import com.sparta.kidscafe.domain.room.entity.Room;
+import com.sparta.kidscafe.exception.BusinessException;
+import com.sparta.kidscafe.exception.ErrorCode;
+import java.time.LocalDate;
+import java.time.format.TextStyle;
+import java.util.List;
+import java.util.Locale;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationCalculationService {
+
+  private final PricePolicyRepository pricePolicyRepository;
+  private final FeeRepository feeRepository;
+
+  public int calculateTotalPrice(Cafe cafe, Room room,
+      List<ReservationCreateRequestDto.ReservationDetailRequestDto> details) {
+    // 기본 룸 가격 추가
+    int totalPrice = room.getPrice();
+
+    for (ReservationCreateRequestDto.ReservationDetailRequestDto detail : details) {
+      if (detail.getTargetType() == TargetType.FEE) {
+        Fee fee = feeRepository.findById(detail.getTargetId())
+            .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_FEE_ID));
+        totalPrice += fee.getFee() * detail.getCount();
+      } else {
+        throw new BusinessException(ErrorCode.UNSUPPORTED_TARGET_TYPE);
+      }
+    }
+    // PricePolicy에 따른 배율 적용
+    List<PricePolicy> policies = pricePolicyRepository.findByCafeIdAndDayTypeContains(cafe.getId(),
+        getCurrentDayType());
+    for (PricePolicy policy : policies) {
+      totalPrice *= policy.getRate();
+    }
+    return totalPrice;
+  }
+
+  private String getCurrentDayType() {
+    String today = LocalDate
+        .now()
+        .getDayOfWeek()
+        .getDisplayName(TextStyle.SHORT, Locale.KOREAN);
+    return today;
+  }
+}

--- a/src/main/java/com/sparta/kidscafe/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/sparta/kidscafe/domain/reservation/service/ReservationService.java
@@ -1,13 +1,76 @@
 package com.sparta.kidscafe.domain.reservation.service;
 
-import com.sparta.kidscafe.domain.reservation.repository.ReservationDetailRepository;
+import com.sparta.kidscafe.common.dto.AuthUser;
+import com.sparta.kidscafe.common.dto.StatusDto;
+import com.sparta.kidscafe.common.enums.RoleType;
+import com.sparta.kidscafe.common.enums.TargetType;
+import com.sparta.kidscafe.domain.cafe.entity.Cafe;
+import com.sparta.kidscafe.domain.cafe.repository.CafeRepository;
+import com.sparta.kidscafe.domain.reservation.dto.request.ReservationCreateRequestDto;
+import com.sparta.kidscafe.domain.reservation.entity.Reservation;
 import com.sparta.kidscafe.domain.reservation.repository.ReservationRepository;
+import com.sparta.kidscafe.domain.room.entity.Room;
+import com.sparta.kidscafe.domain.room.repository.RoomRepository;
+import com.sparta.kidscafe.domain.user.entity.User;
+import com.sparta.kidscafe.domain.user.repository.UserRepository;
+import com.sparta.kidscafe.exception.BusinessException;
+import com.sparta.kidscafe.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class ReservationService {
+
   private final ReservationRepository reservationRepository;
-  private final ReservationDetailRepository reservationDetailRepository;
+  private final RoomRepository roomRepository;
+  private final ReservationCalculationService reservationCalculationService;
+  private final CafeRepository cafeRepository;
+  private final UserRepository userRepository;
+
+  @Transactional
+  public StatusDto createReservation(AuthUser authUser, Long cafeId,
+      ReservationCreateRequestDto requestDto) {
+    // 1. 유저 확인
+    Long userId = authUser.getId();
+    User user = userRepository.findById(userId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    if (!authUser.getRoleType().equals(RoleType.USER)) {
+      throw new BusinessException(ErrorCode.BAD_REQUEST);
+    }
+    // 2. 카페 확인
+    Cafe cafe = cafeRepository.findById(cafeId)
+        .orElseThrow(() -> new BusinessException(ErrorCode.CAFE_NOT_FOUND));
+
+    // 3. 룸 확인
+    Room room = roomRepository.findById(requestDto.getDetails()
+            .stream().filter(item -> item.getTargetType().equals(TargetType.ROOM)).findFirst()
+            .get().getTargetId())
+        .orElseThrow(() -> new BusinessException(ErrorCode.ROOM_NOT_FOUND));
+    // 룸이 존재하지 않을 경우 예외 처리
+    if (!cafe.getRooms().contains(room)) {
+      throw new BusinessException(ErrorCode.BAD_REQUEST);
+    }
+
+    // 4. totalPrice 계산
+    int totalPrice = reservationCalculationService.calculateTotalPrice(cafe, room,
+        requestDto.getDetails());
+
+    // 5. 예약 생성
+    Reservation reservation = Reservation.builder()
+        .cafe(cafe)
+        .user(user)
+        .startedAt(requestDto.getStartedAt())
+        .finishedAt(requestDto.getFinishedAt())
+        .totalPrice(totalPrice)
+        .build();
+
+    reservationRepository.save(reservation);
+    return StatusDto.builder()
+        .status(HttpStatus.CREATED.value())
+        .message("예약 완료")
+        .build();
+  }
 }

--- a/src/main/java/com/sparta/kidscafe/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/kidscafe/exception/ErrorCode.java
@@ -31,6 +31,9 @@ public enum ErrorCode {
     PRICE_POLICY_NOT_FOUND("PRICE_POLICY_NOT_FOUND", "가격 정책을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     PRICE_POLICY_MISMATCH("PRICE_POLICY_MISMATCH", "카페에 해당하지 않는 가격 정책입니다.", HttpStatus.BAD_REQUEST),
 
+    // Fee 관련 에러
+    INVALID_FEE_ID("INVALID_FEE_ID", "유효하지 않은 입장료입니다.", HttpStatus.BAD_REQUEST),
+    UNSUPPORTED_TARGET_TYPE("UNSUPPORTED_TARGET_TYPE", "지원하지 않는 유형입니다.", HttpStatus.BAD_REQUEST),
     // 신고 관련 에러
     REPORT_NOT_FOUND("REPORT_NOT_FOUND","신고를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     INVALID_REPORT_STATUS("INVALID_REPORT_STATUS", "잘못된 신고 상태입니다.", HttpStatus.BAD_REQUEST),


### PR DESCRIPTION
### 시나리오
- `POST` `/api/reservations/cafes/{cafeId}`

1. 사용자가 원하는 카페 예약
2. 예약에 필요한 TotalPrice 계산 메서드 구현
-> Fee 업데이트 후 수정해야함

### 단위 테스트: 테스트 코드 미작성
**※ 순서대로 테스트 할 것:** ReservationService 내에 ReservationCalculationService 메서드가 포함되어 있음
- ReservationCalculationServiceTest
- ReservationServiceTest


#### 추가될 내용
- ReservationCalculationServiceTest
 1. TotalPrice 계산: 성공
 2. TotalPrice 계산: 실패 - 예외는 추후 추가할 예정
- ReservationServiceTest
 1. 예약 생성: 성공
 4. 예약 생성: 실패 - 권한 없음(USER가 아닌 경우)
 5. 예약 생성: 실패 - 존재하지 않는 카페
 6. 예약 생성: 실패 - 존재하지 않는 룸


### 관련 이슈
#64 