### PR TITLE
예약 내역 조회(사용자용) 기능

### DIFF
--- a/src/main/java/com/sparta/kidscafe/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/com/sparta/kidscafe/domain/reservation/controller/ReservationController.java
@@ -2,17 +2,21 @@ package com.sparta.kidscafe.domain.reservation.controller;
 
 import com.sparta.kidscafe.common.annotation.Auth;
 import com.sparta.kidscafe.common.dto.AuthUser;
+import com.sparta.kidscafe.common.dto.PageResponseDto;
 import com.sparta.kidscafe.common.dto.StatusDto;
 import com.sparta.kidscafe.domain.reservation.dto.request.ReservationCreateRequestDto;
+import com.sparta.kidscafe.domain.reservation.dto.response.ReservationResponseDto;
 import com.sparta.kidscafe.domain.reservation.service.ReservationService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -22,6 +26,7 @@ public class ReservationController {
 
   private final ReservationService reservationService;
 
+  // 예약 생성
   @PostMapping("/reservations/cafes/{cafeId}")
   public ResponseEntity<StatusDto> createReservation(
       @Auth AuthUser authUser,
@@ -31,6 +36,16 @@ public class ReservationController {
     return ResponseEntity.status(HttpStatus.CREATED).body(response);
   }
 
+  // 예약 내역 조회(User용)
+  @GetMapping("/users/reservations")
+  public ResponseEntity<PageResponseDto<ReservationResponseDto>> getReservationsByUser(
+      @Auth AuthUser authUser,
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "10") int size) {
+    PageResponseDto<ReservationResponseDto> response = reservationService.getReservationsByUser(
+        authUser, page, size);
+    return ResponseEntity.ok(response);
+  }
 
 
 }

--- a/src/main/java/com/sparta/kidscafe/domain/reservation/dto/response/ReservationResponseDto.java
+++ b/src/main/java/com/sparta/kidscafe/domain/reservation/dto/response/ReservationResponseDto.java
@@ -16,6 +16,7 @@ import lombok.NoArgsConstructor;
 public class ReservationResponseDto {
 
   private Long reservationId;
+  private Long cafeId;
   private String cafeName;
   private String roomName;
   private LocalDateTime startedAt;

--- a/src/main/java/com/sparta/kidscafe/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/sparta/kidscafe/domain/reservation/repository/ReservationRepository.java
@@ -1,7 +1,11 @@
 package com.sparta.kidscafe.domain.reservation.repository;
 
 import com.sparta.kidscafe.domain.reservation.entity.Reservation;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+
+  Page<Reservation> findByUserId(Long userId, Pageable pageable);
 }


### PR DESCRIPTION
### 시나리오
- `GET` `/api/users/reservations`

1. 사용자의 예약 내역(목록) 조회

### 단위 테스트 (예정)
- ReservationServiceTest에서 진행

1. 사용자 전용 예약 내역 조회: 성공
2. 사용자 전용 예약 내역 조회: 실패 - 권한 없음(User가 아닌 경우)
3. 사용자 전용 예약 내역 조회: 실패 - 예약 내역이 비어있는 경우

### 관련 이슈
#65 