### PR TITLE
예약 내역 조회(카페용) 기능 구현

### DIFF
--- a/src/main/java/com/sparta/kidscafe/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/com/sparta/kidscafe/domain/reservation/controller/ReservationController.java
@@ -47,5 +47,17 @@ public class ReservationController {
     return ResponseEntity.ok(response);
   }
 
+  // 예약 내역 조회(Owner용)
+  @GetMapping("owners/reservations/cafes/{cafeId}")
+  public ResponseEntity<PageResponseDto<ReservationResponseDto>> getReservationsByOwner(
+      @Auth AuthUser authUser,
+      @PathVariable Long cafeId,
+      @RequestParam(defaultValue = "0") int page,
+      @RequestParam(defaultValue = "10") int size) {
+    PageResponseDto<ReservationResponseDto> response = reservationService.getReservationsByOwner(
+        authUser, cafeId, page, size);
+    return ResponseEntity.ok(response);
+  }
+
 
 }

--- a/src/main/java/com/sparta/kidscafe/domain/reservation/dto/response/ReservationResponseDto.java
+++ b/src/main/java/com/sparta/kidscafe/domain/reservation/dto/response/ReservationResponseDto.java
@@ -16,7 +16,9 @@ import lombok.NoArgsConstructor;
 public class ReservationResponseDto {
 
   private Long reservationId;
+  private Long userId;
   private Long cafeId;
+  private String userName;
   private String cafeName;
   private String roomName;
   private LocalDateTime startedAt;
@@ -31,6 +33,7 @@ public class ReservationResponseDto {
   @AllArgsConstructor
   public static class ReservationDetailResponseDto {
     private TargetType targetType;
+    private Long targetId;
     private String targetName;
     private int price;
     private Long count;

--- a/src/main/java/com/sparta/kidscafe/domain/reservation/dto/response/ReservationResponseDto.java
+++ b/src/main/java/com/sparta/kidscafe/domain/reservation/dto/response/ReservationResponseDto.java
@@ -5,7 +5,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/com/sparta/kidscafe/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/com/sparta/kidscafe/domain/reservation/repository/ReservationRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
 
   Page<Reservation> findByUserId(Long userId, Pageable pageable);
+
+  Page<Reservation> findByCafeId(Long cafeId, Pageable pageable);
 }

--- a/src/main/java/com/sparta/kidscafe/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/sparta/kidscafe/domain/reservation/service/ReservationService.java
@@ -84,8 +84,12 @@ public class ReservationService {
   // 예약 내역 조회(User용)
   @Transactional(readOnly = true)
   public PageResponseDto<ReservationResponseDto> getReservationsByUser(AuthUser authUser, int page, int size) {
+    if (!authUser.getRoleType().equals(RoleType.USER)) {
+      throw new BusinessException(ErrorCode.UNAUTHORIZED);
+    }
     Pageable pageable = PageRequest.of(page, size, Sort.by(Direction.DESC, "createdAt"));
     Page<Reservation> reservationsForUser = reservationRepository.findByUserId(authUser.getId(), pageable);
+
 
     Page<ReservationResponseDto> responseDtos = reservationsForUser.map(reservation ->
         ReservationResponseDto.builder()

--- a/src/main/java/com/sparta/kidscafe/domain/reservation/service/ReservationService.java
+++ b/src/main/java/com/sparta/kidscafe/domain/reservation/service/ReservationService.java
@@ -1,6 +1,5 @@
 package com.sparta.kidscafe.domain.reservation.service;
 
-import com.sparta.kidscafe.common.annotation.Auth;
 import com.sparta.kidscafe.common.dto.AuthUser;
 import com.sparta.kidscafe.common.dto.PageResponseDto;
 import com.sparta.kidscafe.common.dto.StatusDto;


### PR DESCRIPTION
### 시나리오
- `GET` `/api/owners/reservations/cafes/{cafeId}`

1. 카페의 예약 내역(목록) 조회

### 단위 테스트 (예정)
- ReservationServiceTest에서 진행

1. 카페 전용 예약 내역 조회: 성공
2. 카페 전용 예약 내역 조회: 실패 - 권한 없음(Owner가 아닌 경우)
3. 카페 전용 예약 내역 조회: 실패 - Owner가 소유한 카페가 아닐때

### 관련 이슈
#66 