### PR TITLE
feat: 회원 조회(사장님 가게를 즐겨찾기한 사람들) 기능 구현 #5

### DIFF
--- a/src/main/java/com/sparta/kidscafe/domain/user/controller/UserOwnerController.java
+++ b/src/main/java/com/sparta/kidscafe/domain/user/controller/UserOwnerController.java
@@ -1,0 +1,39 @@
+package com.sparta.kidscafe.domain.user.controller;
+
+import com.sparta.kidscafe.common.annotation.Auth;
+import com.sparta.kidscafe.common.dto.AuthUser;
+import com.sparta.kidscafe.common.dto.ListResponseDto;
+import com.sparta.kidscafe.common.enums.RoleType;
+import com.sparta.kidscafe.domain.user.dto.response.UserResponseDto;
+import com.sparta.kidscafe.domain.user.service.UserOwnerService;
+import com.sparta.kidscafe.exception.BusinessException;
+import com.sparta.kidscafe.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class UserOwnerController {
+
+    private final UserOwnerService userOwnerService;
+
+    @GetMapping("/api/owners/users")
+    public ResponseEntity<ListResponseDto<UserResponseDto>> getUsersWhoFavoritedOwner(
+            @Auth AuthUser authUser,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        // 인증된 사용자 정보 활용 (OWNER 권한 확인)
+        if (authUser.getRoleType() != RoleType.OWNER) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+
+        // UserOwnerService에서 ListResponseDto 반환
+        ListResponseDto<UserResponseDto> responseDto = userOwnerService.getUsersWhoFavoritedOwner(authUser, page, size);
+
+        return ResponseEntity.ok(responseDto);
+    }
+}

--- a/src/main/java/com/sparta/kidscafe/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/sparta/kidscafe/domain/user/repository/UserRepository.java
@@ -18,4 +18,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     // 이메일로 사용자 정보 조회
     Optional<User> findByEmail(String email);
+
+    // 사장님의 가게를 즐겨찾기한 사용자 목록을 페이징 처리하여 반환
+    Page<User> findUsersByBookmarks_OwnerId(Long ownerId, Pageable pageable);
 }

--- a/src/main/java/com/sparta/kidscafe/domain/user/service/UserOwnerService.java
+++ b/src/main/java/com/sparta/kidscafe/domain/user/service/UserOwnerService.java
@@ -1,0 +1,45 @@
+package com.sparta.kidscafe.domain.user.service;
+
+import com.sparta.kidscafe.common.dto.AuthUser;
+import com.sparta.kidscafe.common.dto.ListResponseDto;
+import com.sparta.kidscafe.domain.user.dto.response.UserResponseDto;
+import com.sparta.kidscafe.domain.user.entity.User;
+import com.sparta.kidscafe.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class UserOwnerService {
+
+    private final UserRepository userRepository;
+
+    public ListResponseDto<UserResponseDto> getUsersWhoFavoritedOwner(AuthUser authUser, int page, int size) {
+        // authUser에서 ownerId 가져오기
+        Long ownerId = authUser.getId();
+
+        // PageRequest 생성 (0-based index 사용)
+        PageRequest pageRequest = PageRequest.of(page - 1, size);
+
+        // 사장님의 가게를 즐겨찾기한 사용자 조회 및 페이징 처리
+        Page<User> userPage = userRepository.findUsersByBookmarks_OwnerId(ownerId, pageRequest);
+
+        // 사용자 목록을 DTO로 변환
+        List<UserResponseDto> users = userPage.getContent().stream()
+                .map(UserResponseDto::fromEntity)
+                .collect(Collectors.toList());
+
+        // ListResponseDto로 감싸서 반환
+        return ListResponseDto.success(
+                users,
+                HttpStatus.OK,
+                "회원 조회 성공"
+        );
+    }
+}


### PR DESCRIPTION
### 구현 사항 🐧🩷
**1. 회원 조회 API**
- /api/owners/users
- OWNER 권한을 가진 사용자가 자신의 가게를 즐겨찾기한 사용자 목록을 조회할 수 있는 기능 구현

**2. Authorization 확인**
- @Auth 어노테이션을 사용하여 JWT로부터 인증된 사용자 정보(AuthUser)를 추출
- OWNER 권한 확인 후 비즈니스 로직 실행
- OWNER 권한이 아닐 경우, ErrorCode.FORBIDDEN을 활용한 예외 처리

**3. 페이징 처리**
- UserOwnerService에서 PageRequest를 사용하여 페이징 처리 로직 구현
- 즐겨찾기 데이터를 기준으로 조회된 사용자 목록을 페이징 처리 후 반환

**4. 응답 데이터 형식 통일**
- ListResponseDto로 데이터 응답 형식을 통일.
- 사용자 데이터(UserResponseDto)를 변환하여 클라이언트에 제공

**5. Repository 메서드 추가**
- UserRepository에 findUsersByBookmarks_OwnerId 메서드 추가하여 즐겨찾기 데이터를 기준으로 사용자 목록 조회 지원

 **postman테스트**
-  OWNER 권한을 가진 사용자가 자신의 가게를 즐겨찾기한 사용자 목록을 정상적으로 조회하는지 확인
-  OWNER 권한이 없는 사용자가 요청할 경우, 403 Forbidden 응답이 반환되는지 확인
-  페이징 처리 동작 확인 (page, size 값에 따른 응답 확인)
-  응답 데이터가 요구사항에 맞는 형식으로 반환되는지 확인

@gaeul79 @Dohyeon-Parrk @gyeonwoo-jerry @dameun0527 