### PR TITLE
Feat/8 user 회원 탈퇴

### DIFF
--- a/src/main/java/com/sparta/kidscafe/domain/user/controller/UserProfileController.java
+++ b/src/main/java/com/sparta/kidscafe/domain/user/controller/UserProfileController.java
@@ -4,6 +4,7 @@ import com.sparta.kidscafe.common.annotation.Auth;
 import com.sparta.kidscafe.common.dto.AuthUser;
 import com.sparta.kidscafe.common.dto.ResponseDto;
 import com.sparta.kidscafe.common.enums.RoleType;
+import com.sparta.kidscafe.domain.user.dto.request.UserDeleteRequestDto;
 import com.sparta.kidscafe.domain.user.dto.request.UserProfileUpdateRequestDto;
 import com.sparta.kidscafe.domain.user.dto.response.UserProfileResponseDto;
 import com.sparta.kidscafe.domain.user.service.UserProfileService;
@@ -11,11 +12,9 @@ import com.sparta.kidscafe.exception.BusinessException;
 import com.sparta.kidscafe.exception.ErrorCode;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -51,4 +50,13 @@ public class UserProfileController {
         return ResponseEntity.ok(responseDto);
     }
 
+    @DeleteMapping("/api/users/me")
+    public ResponseEntity<ResponseDto<Void>> deleteUser(
+            @Auth AuthUser authUser,
+            @RequestBody @Valid UserDeleteRequestDto requestDto) {
+        // 서비스 계층에서 회원 탈퇴 처리
+        userProfileService.deleteUser(authUser, requestDto);
+
+        return ResponseEntity.ok(ResponseDto.success(null, HttpStatus.OK, "회원 탈퇴 성공"));
+    }
 }

--- a/src/main/java/com/sparta/kidscafe/domain/user/dto/request/UserDeleteRequestDto.java
+++ b/src/main/java/com/sparta/kidscafe/domain/user/dto/request/UserDeleteRequestDto.java
@@ -1,0 +1,11 @@
+package com.sparta.kidscafe.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+public class UserDeleteRequestDto {
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    private String password;
+}

--- a/src/main/java/com/sparta/kidscafe/domain/user/service/UserProfileService.java
+++ b/src/main/java/com/sparta/kidscafe/domain/user/service/UserProfileService.java
@@ -3,6 +3,7 @@ package com.sparta.kidscafe.domain.user.service;
 import com.sparta.kidscafe.common.dto.AuthUser;
 import com.sparta.kidscafe.common.dto.ResponseDto;
 import com.sparta.kidscafe.common.util.PasswordEncoder;
+import com.sparta.kidscafe.domain.user.dto.request.UserDeleteRequestDto;
 import com.sparta.kidscafe.domain.user.dto.request.UserProfileUpdateRequestDto;
 import com.sparta.kidscafe.domain.user.dto.response.UserProfileResponseDto;
 import com.sparta.kidscafe.domain.user.entity.User;
@@ -54,5 +55,19 @@ public class UserProfileService {
                 HttpStatus.OK,
                 "프로필 수정 성공"
         );
+    }
+
+    @Transactional
+    public void deleteUser(AuthUser authUser, UserDeleteRequestDto requestDto) {
+        User user = userRepository.findById(authUser.getId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        // 비밀번호 검증
+        if (!passwordEncoder.matches(requestDto.getPassword(), user.getPassword())) {
+            throw new BusinessException(ErrorCode.INVALID_PASSWORD);
+        }
+
+        // 사용자 삭제
+        userRepository.delete(user);
     }
 }

--- a/src/main/java/com/sparta/kidscafe/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/kidscafe/exception/ErrorCode.java
@@ -9,6 +9,7 @@ public enum ErrorCode {
     USER_NOT_FOUND("USER_NOT_FOUND", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     DUPLICATE_EMAIL("DUPLICATE_EMAIL", "이미 사용 중인 이메일입니다.", HttpStatus.BAD_REQUEST),
     WRONG_PASSWORD("WRONG_PASSWORD", "비밀번호가 틀립니다.", HttpStatus.BAD_REQUEST),
+    INVALID_PASSWORD("INVALID_PASSWORD", "잘못된 비밀번호입니다.", HttpStatus.BAD_REQUEST),
 
     // Cafe 관련 에러
     CAFE_NOT_FOUND("CAFE_NOT_FOUND", "카페를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
@@ -22,12 +23,14 @@ public enum ErrorCode {
     // Review 관련 에러
     REVIEW_NOT_FOUND("REVIEW_NOT_FOUND", "리뷰를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     IMAGE_NOT_FOUND("IMAGE_NOT_FOUND", "이미지를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+
     // Room 관련에러
     ROOM_NOT_FOUND("ROOM_NOT_FOUND","룸을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
 
     // Reservation 관련 에러
     RESERVATION_NOT_FOUND("RESERVATION_NOT_FOUND", "예약을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     INVALID_STATUS_CHANGE("INVALID_STATUS_CHANGE", "유효하지 않은 상태입니다.", HttpStatus.BAD_REQUEST),
+
     // Bookmark 관련 에러
     NO_BOOKMARKS_FOUND("NO_BOOKMARKS_FOUND", "즐겨찾기 목록이 비어있습니다.", HttpStatus.NOT_FOUND),
 


### PR DESCRIPTION
### 어떤 **변경 사항**이 있나요?
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [x] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

PR이 다음 **요구 사항을 충족**하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. Commit message convention 참고 (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### **회원 탈퇴 기능 구현**
- **UserProfileController**
 - `/api/users/me` DELETE API 추가
- AuthUser와 UserDeleteRequestDto를 사용하여 회원 탈퇴 처리

### **UserProfileService**
- deleteUser 메서드 추가
- 비밀번호 검증 후 사용자 삭제 처리
- PasswordEncoder를 이용한 비밀번호 검증 로직 구현
- **UserDeleteRequestDto** : `password` 필드 추가 및 @NotBlank로 유효성 검증

### **주요 변경 사항**
- ErrorCode enum에 INVALID_PASSWORD 추가(코드: INVALID_PASSWORD, 메시지: "잘못된 비밀번호입니다.", HttpStatus: BAD_REQUEST)
- 비밀번호 검증 실패 시 적합한 에러 메시지를 제공하기 위해 추가됨

### **postman 테스트 결과**
- INVALID_PASSWORD 에러가 정상적으로 반환되는지 확인 완료

@gaeul79 @Dohyeon-Parrk @gyeonwoo-jerry @dameun0527 